### PR TITLE
chore(license): apply BSD 3-Clause license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.kr.md
+++ b/README.kr.md
@@ -3,7 +3,7 @@
 > **macOS 시스템 정리 도구** - 안전하게 불필요한 파일을 정리하여 디스크 공간을 확보합니다.
 
 [![macOS](https://img.shields.io/badge/macOS-10.15--15.x-blue.svg)](https://www.apple.com/macos/)
-[![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
+[![License](https://img.shields.io/badge/License-BSD--3--Clause-blue.svg)](LICENSE)
 [![Status](https://img.shields.io/badge/Status-Development-orange.svg)]()
 
 ---

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > **macOS System Cleaning Tool** - Safely clean unnecessary files to free up disk space.
 
 [![macOS](https://img.shields.io/badge/macOS-10.15--15.x-blue.svg)](https://www.apple.com/macos/)
-[![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
+[![License](https://img.shields.io/badge/License-BSD--3--Clause-blue.svg)](LICENSE)
 [![Status](https://img.shields.io/badge/Status-Development-orange.svg)]()
 
 ---

--- a/Sources/OSXCleanerKit/Bridge/FFITypes.swift
+++ b/Sources/OSXCleanerKit/Bridge/FFITypes.swift
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+
 import Foundation
 
 // MARK: - Analysis Types (from Rust scanner module)

--- a/Sources/OSXCleanerKit/Bridge/RustBridge.swift
+++ b/Sources/OSXCleanerKit/Bridge/RustBridge.swift
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+
 import COSXCore
 import Foundation
 

--- a/Sources/OSXCleanerKit/Config/Configuration.swift
+++ b/Sources/OSXCleanerKit/Config/Configuration.swift
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+
 import Foundation
 
 /// Application configuration

--- a/Sources/OSXCleanerKit/Logger/Logger.swift
+++ b/Sources/OSXCleanerKit/Logger/Logger.swift
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+
 import Foundation
 import Logging
 

--- a/Sources/OSXCleanerKit/Services/AnalyzerService.swift
+++ b/Sources/OSXCleanerKit/Services/AnalyzerService.swift
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+
 import Foundation
 
 /// Result of disk analysis

--- a/Sources/OSXCleanerKit/Services/CleanerService.swift
+++ b/Sources/OSXCleanerKit/Services/CleanerService.swift
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+
 import Foundation
 
 /// Result of a cleanup operation

--- a/Sources/osxcleaner/Commands/AnalyzeCommand.swift
+++ b/Sources/osxcleaner/Commands/AnalyzeCommand.swift
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+
 import ArgumentParser
 import Foundation
 import OSXCleanerKit

--- a/Sources/osxcleaner/Commands/CleanCommand.swift
+++ b/Sources/osxcleaner/Commands/CleanCommand.swift
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+
 import ArgumentParser
 import Foundation
 import OSXCleanerKit

--- a/Sources/osxcleaner/Commands/ConfigCommand.swift
+++ b/Sources/osxcleaner/Commands/ConfigCommand.swift
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+
 import ArgumentParser
 import OSXCleanerKit
 

--- a/Sources/osxcleaner/Commands/ScheduleCommand.swift
+++ b/Sources/osxcleaner/Commands/ScheduleCommand.swift
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+
 import ArgumentParser
 import Foundation
 import OSXCleanerKit

--- a/Sources/osxcleaner/OSXCleaner.swift
+++ b/Sources/osxcleaner/OSXCleaner.swift
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+
 import ArgumentParser
 import OSXCleanerKit
 

--- a/Sources/osxcleaner/Types/CLITypes.swift
+++ b/Sources/osxcleaner/Types/CLITypes.swift
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+
 import ArgumentParser
 import OSXCleanerKit
 

--- a/Sources/osxcleaner/UI/ProgressView.swift
+++ b/Sources/osxcleaner/UI/ProgressView.swift
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+
 import Foundation
 
 /// Simple progress display for CLI output

--- a/rust-core/Cargo.toml
+++ b/rust-core/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 rust-version = "1.75"
 description = "Core engine for OSX Cleaner - file scanning, cleanup, and safety validation"
-license = "MIT"
+license = "BSD-3-Clause"
 
 [lib]
 name = "osxcore"

--- a/rust-core/build.rs
+++ b/rust-core/build.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+
 use std::env;
 use std::path::PathBuf;
 

--- a/rust-core/src/cleaner/mod.rs
+++ b/rust-core/src/cleaner/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+
 //! Cleanup execution module
 //!
 //! Provides safe file and directory cleanup with rollback support.

--- a/rust-core/src/fs/mod.rs
+++ b/rust-core/src/fs/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+
 //! File system utilities module
 //!
 //! Provides file system abstractions and utilities for the cleaner.

--- a/rust-core/src/lib.rs
+++ b/rust-core/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+
 //! OSX Cleaner Core Engine
 //!
 //! This crate provides the core functionality for OSX Cleaner:

--- a/rust-core/src/safety/cloud.rs
+++ b/rust-core/src/safety/cloud.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+
 //! Cloud sync status detection module
 //!
 //! Detects if files are being synced by cloud services to prevent data loss.

--- a/rust-core/src/safety/level.rs
+++ b/rust-core/src/safety/level.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+
 //! Safety level definitions
 //!
 //! Defines the 4-level safety classification system for cleanup operations.

--- a/rust-core/src/safety/mod.rs
+++ b/rust-core/src/safety/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+
 //! Safety validation module
 //!
 //! Provides comprehensive safety validation for cleanup operations:

--- a/rust-core/src/safety/paths.rs
+++ b/rust-core/src/safety/paths.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+
 //! Path definitions for safety classification
 //!
 //! Defines protected paths (DANGER) and warning paths (WARNING) that require

--- a/rust-core/src/safety/process.rs
+++ b/rust-core/src/safety/process.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+
 //! Running process detection module
 //!
 //! Detects running applications to prevent cache deletion while they're in use.

--- a/rust-core/src/safety/validator.rs
+++ b/rust-core/src/safety/validator.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+
 //! Safety validator module
 //!
 //! Provides centralized validation logic for cleanup operations.

--- a/rust-core/src/scanner/mod.rs
+++ b/rust-core/src/scanner/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+
 //! File system scanner module
 //!
 //! Provides parallel directory scanning and analysis capabilities.


### PR DESCRIPTION
## Summary

- Add BSD 3-Clause license to the project
- Update all source files with SPDX license headers
- Update documentation with correct license badges

## Changes

| Category | Files | Description |
|----------|-------|-------------|
| LICENSE | 1 | Add BSD 3-Clause license file |
| README | 2 | Update license badges (MIT → BSD-3-Clause) |
| Swift | 13 | Add SPDX license headers |
| Rust | 12 | Add SPDX license headers |
| Cargo.toml | 1 | Update license field |

**Total: 28 files changed**

## License Header Format

All source files now include:
```
// SPDX-License-Identifier: BSD-3-Clause
// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
```

## Test Plan

- [x] Verify LICENSE file content matches BSD 3-Clause template
- [x] Verify all Swift source files have license headers
- [x] Verify all Rust source files have license headers
- [x] Verify README badges display correctly
- [x] Verify Cargo.toml license field is valid SPDX identifier