### PR TITLE
feat(ffi): add cloud sync detection FFI bindings

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `osx_get_app_cache_paths`: Get cache paths for an application
   - Comprehensive FFI unit tests (10 test cases)
 
+- **F01-6: Cloud Sync Status Detection FFI Bindings** (#26)
+  - `osx_detect_cloud_service`: Detect cloud service (iCloud, Dropbox, OneDrive, Google Drive)
+  - `osx_get_cloud_sync_info`: Get detailed sync status information
+  - `osx_is_safe_to_delete_cloud`: Check if safe to delete from cloud perspective
+  - `osx_is_icloud_path`: Check if path is in iCloud location
+  - `osx_is_dropbox_path`: Check if path is in Dropbox location
+  - `osx_is_onedrive_path`: Check if path is in OneDrive location
+  - `osx_is_google_drive_path`: Check if path is in Google Drive location
+  - Comprehensive FFI unit tests (16 test cases)
+
 - **F05: Time Machine Snapshot Management** (#9)
 
   - TimeMachineService for managing local APFS snapshots

--- a/include/osxcore.h
+++ b/include/osxcore.h
@@ -278,6 +278,74 @@ struct osx_FFIResult osx_get_processes_using_path(const char *path);
 struct osx_FFIResult osx_get_app_cache_paths(const char *app_name);
 
 /**
+ * Detect which cloud service (if any) a path belongs to
+ *
+ * # Safety
+ * - `path` must be a valid null-terminated C string
+ * - The returned FFIResult must be freed with `osx_free_result`
+ * - Returns JSON: {"service": "iCloud"|"Dropbox"|"OneDrive"|"Google Drive"|null, "is_cloud_path": bool}
+ */
+struct osx_FFIResult osx_detect_cloud_service(const char *path);
+
+/**
+ * Get detailed cloud sync information for a path
+ *
+ * # Safety
+ * - `path` must be a valid null-terminated C string
+ * - The returned FFIResult must be freed with `osx_free_result`
+ * - Returns JSON: {"service": "...", "status": "...", "path": "...", "is_cloud_path": bool}
+ * - Status can be: "Synced", "Syncing", "Pending", "CloudOnly", "LocalOnly", "Error", "NotApplicable"
+ */
+struct osx_FFIResult osx_get_cloud_sync_info(const char *path);
+
+/**
+ * Check if a path is safe to delete from a cloud sync perspective
+ *
+ * # Safety
+ * - `path` must be a valid null-terminated C string
+ * - The returned FFIResult must be freed with `osx_free_result`
+ * - Returns JSON: {"safe": bool, "warning": "..." or null}
+ * - If not safe, warning explains why (e.g., "File is currently syncing to iCloud")
+ */
+struct osx_FFIResult osx_is_safe_to_delete_cloud(const char *path);
+
+/**
+ * Check if a path is within an iCloud synced location
+ *
+ * # Safety
+ * - `path` must be a valid null-terminated C string
+ * - Returns true if the path is in an iCloud location, false otherwise
+ */
+bool osx_is_icloud_path(const char *path);
+
+/**
+ * Check if a path is within a Dropbox synced location
+ *
+ * # Safety
+ * - `path` must be a valid null-terminated C string
+ * - Returns true if the path is in a Dropbox location, false otherwise
+ */
+bool osx_is_dropbox_path(const char *path);
+
+/**
+ * Check if a path is within a OneDrive synced location
+ *
+ * # Safety
+ * - `path` must be a valid null-terminated C string
+ * - Returns true if the path is in a OneDrive location, false otherwise
+ */
+bool osx_is_onedrive_path(const char *path);
+
+/**
+ * Check if a path is within a Google Drive synced location
+ *
+ * # Safety
+ * - `path` must be a valid null-terminated C string
+ * - Returns true if the path is in a Google Drive location, false otherwise
+ */
+bool osx_is_google_drive_path(const char *path);
+
+/**
  * Get system information as JSON
  *
  * # Safety


### PR DESCRIPTION
## Summary
- Add comprehensive FFI bindings for cloud sync status detection (F01-6)
- Enable Swift layer to detect and handle cloud-synced files safely
- Support iCloud, Dropbox, OneDrive, and Google Drive

## Changes
### New FFI Functions
| Function | Description |
|----------|-------------|
| `osx_detect_cloud_service` | Detect cloud service for a path |
| `osx_get_cloud_sync_info` | Get detailed sync status information |
| `osx_is_safe_to_delete_cloud` | Check if safe to delete from cloud perspective |
| `osx_is_icloud_path` | Check if path is in iCloud location |
| `osx_is_dropbox_path` | Check if path is in Dropbox location |
| `osx_is_onedrive_path` | Check if path is in OneDrive location |
| `osx_is_google_drive_path` | Check if path is in Google Drive location |

### Files Changed
- `rust-core/src/lib.rs`: Add 7 FFI functions with comprehensive documentation
- `include/osxcore.h`: Auto-generated C header with new function declarations
- `docs/CHANGELOG.md`: Document new FFI bindings

## Test plan
- [x] All 16 new unit tests pass
- [x] All 190 total tests pass (169 unit + 21 integration)
- [x] Tests cover null pointer handling, local paths, and cloud paths

Closes #26