### PR TITLE
test(simulator): expand test coverage for SimulatorCleaner

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -88,6 +88,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Comprehensive test suite (14 unit tests)
 
 ### Testing
+- **F02-3: SimulatorCleaner Test Coverage Expansion** (#34)
+  - JSON parsing tests for `xcrun simctl list devices` output
+  - JSON parsing tests for `xcrun simctl runtime list` output
+  - Tempfile integration tests for cache scanning
+  - Edge case tests for missing/unavailable data handling
+  - Error display tests for SimulatorError
+  - Cleanup target construction tests
+  - Increase test count from 3 to 18
+
 - **F01-8: Comprehensive unit tests for safety module** (#28)
   - Edge case tests (symlinks, permissions, missing paths)
   - Unicode and special character path handling tests


### PR DESCRIPTION
## Summary

- Expand unit test coverage for SimulatorCleaner from 3 to 18 tests
- Add JSON parsing tests for `xcrun simctl` output formats
- Add tempfile-based integration tests for cache scanning

## Changes

### Test Coverage Expansion
- **JSON parsing tests**: Validate parsing of `simctl list devices -j` and `simctl runtime list -j` output formats
- **Missing field handling**: Test graceful handling when optional fields (isAvailable, sizeBytes) are missing
- **Cache scanning tests**: Use tempfile crate for integration testing of cache directory scanning
- **Edge cases**: Empty directories, nonexistent paths, unavailable simulators
- **Error handling**: SimulatorError display formatting tests
- **Struct construction**: CleanupTarget builder pattern tests

### Documentation
- Update CHANGELOG.md with test coverage improvements

## Test Results
All 18 tests passing:
- `test_simulator_cleaner_creation`
- `test_simulator_cleaner_default`
- `test_simulator_device_struct`
- `test_simulator_device_unavailable`
- `test_simulator_runtime_struct`
- `test_simulator_runtime_unavailable`
- `test_simctl_devices_output_parsing`
- `test_simctl_devices_output_missing_is_available`
- `test_simctl_runtimes_output_parsing`
- `test_simctl_runtimes_output_minimal`
- `test_scan_caches_with_temp_directory`
- `test_scan_caches_empty_directory`
- `test_scan_caches_nonexistent`
- `test_simulator_error_display`
- `test_simulator_list_struct`
- `test_cleanup_target_for_unavailable_simulator`
- `test_cleanup_target_for_runtime`
- `test_get_unavailable_simulators_graceful_failure`

## Acceptance Criteria
- [x] AC-03: Enumerate all iOS Simulators with status (available/unavailable)
- [x] AC-07: Delete only unavailable simulators by default

## Test Plan
- [x] Run `cargo test simulator` - all 18 tests pass
- [x] Run `cargo build --release` - no warnings or errors

Closes #34