### PR TITLE
feat(cli): add server and fleet management CLI commands (F14-6)

### DIFF
--- a/Sources/OSXCleanerKit/Config/Configuration.swift
+++ b/Sources/OSXCleanerKit/Config/Configuration.swift
@@ -10,6 +10,14 @@ public struct AppConfiguration: Codable {
     public var logLevel: String
     public var excludedPaths: [String]
 
+    // Server connection settings
+    public var serverURL: String?
+    public var serverTimeout: Int?
+    public var agentId: UUID?
+    public var authToken: String?
+    public var tokenExpiresAt: Date?
+    public var lastHeartbeat: Date?
+
     public static let `default` = AppConfiguration(
         defaultSafetyLevel: 2, // Normal cleanup level
         autoBackup: true,
@@ -27,12 +35,24 @@ public struct AppConfiguration: Codable {
         defaultSafetyLevel: Int = 3,
         autoBackup: Bool = true,
         logLevel: String = "info",
-        excludedPaths: [String] = []
+        excludedPaths: [String] = [],
+        serverURL: String? = nil,
+        serverTimeout: Int? = nil,
+        agentId: UUID? = nil,
+        authToken: String? = nil,
+        tokenExpiresAt: Date? = nil,
+        lastHeartbeat: Date? = nil
     ) {
         self.defaultSafetyLevel = defaultSafetyLevel
         self.autoBackup = autoBackup
         self.logLevel = logLevel
         self.excludedPaths = excludedPaths
+        self.serverURL = serverURL
+        self.serverTimeout = serverTimeout
+        self.agentId = agentId
+        self.authToken = authToken
+        self.tokenExpiresAt = tokenExpiresAt
+        self.lastHeartbeat = lastHeartbeat
     }
 }
 

--- a/Sources/osxcleaner/Commands/FleetCommand.swift
+++ b/Sources/osxcleaner/Commands/FleetCommand.swift
@@ -1,0 +1,534 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+
+import ArgumentParser
+import Foundation
+import OSXCleanerKit
+
+struct FleetCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "fleet",
+        abstract: "Manage fleet of agents from the management server",
+        discussion: """
+            Fleet management commands for administrators to monitor and control
+            connected agents, deploy policies, and generate compliance reports.
+
+            Note: These commands require server-side access. For local agent
+            operations, use 'osxcleaner server' commands instead.
+
+            Examples:
+              osxcleaner fleet agents                     # List all agents
+              osxcleaner fleet status                     # Show fleet statistics
+              osxcleaner fleet deploy my-policy --all    # Deploy policy to all agents
+              osxcleaner fleet compliance                 # Generate compliance report
+            """,
+        subcommands: [
+            Agents.self,
+            FleetStatus.self,
+            Deploy.self,
+            Compliance.self,
+            Audit.self
+        ],
+        defaultSubcommand: FleetStatus.self
+    )
+}
+
+// MARK: - Agents Subcommand
+
+extension FleetCommand {
+    struct Agents: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "agents",
+            abstract: "List all registered agents"
+        )
+
+        @Option(name: .shortAndLong, help: "Filter by connection state (active, offline, pending)")
+        var state: String?
+
+        @Option(name: .long, help: "Filter by tag")
+        var tag: String?
+
+        @Option(name: .long, help: "Filter by capability")
+        var capability: String?
+
+        @Flag(name: .shortAndLong, help: "Show output in JSON format")
+        var json: Bool = false
+
+        mutating func run() async throws {
+            let progressView = ProgressView()
+            let registry = AgentRegistry()
+
+            var agents = await registry.allAgents()
+
+            // Apply filters
+            if let stateFilter = state {
+                if let connectionState = AgentConnectionState(rawValue: stateFilter) {
+                    agents = agents.filter { $0.connectionState == connectionState }
+                }
+            }
+
+            if let tagFilter = tag {
+                agents = agents.filter { $0.identity.tags.contains(tagFilter) }
+            }
+
+            if let capFilter = capability {
+                agents = agents.filter { $0.capabilities.contains(capFilter) }
+            }
+
+            if agents.isEmpty {
+                progressView.display(message: "No agents found")
+                return
+            }
+
+            if json {
+                let output = agents.map { AgentSummary(from: $0) }
+                let encoder = JSONEncoder()
+                encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+                encoder.dateEncodingStrategy = .iso8601
+                let data = try encoder.encode(output)
+                print(String(data: data, encoding: .utf8) ?? "[]")
+            } else {
+                printAgentTable(agents, progressView: progressView)
+            }
+        }
+
+        private func printAgentTable(_ agents: [RegisteredAgent], progressView: ProgressView) {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "MM-dd HH:mm"
+
+            progressView.display(message: "")
+            progressView.display(message: "╔══════════════════════════════════════╤══════════╤══════════════════╤═══════════════╗")
+            progressView.display(message: "║               Agent ID               │  Status  │     Hostname     │  Last Seen    ║")
+            progressView.display(message: "╠══════════════════════════════════════╪══════════╪══════════════════╪═══════════════╣")
+
+            for agent in agents {
+                let id = agent.identity.id.uuidString.prefix(36).padding(toLength: 36, withPad: " ", startingAt: 0)
+                let status = statusIcon(agent.connectionState).padding(toLength: 8, withPad: " ", startingAt: 0)
+                let hostname = String(agent.identity.hostname.prefix(16)).padding(toLength: 16, withPad: " ", startingAt: 0)
+                let lastSeen: String
+                if let heartbeat = agent.lastHeartbeat {
+                    lastSeen = formatter.string(from: heartbeat)
+                } else {
+                    lastSeen = "Never"
+                }
+                let lastSeenPadded = lastSeen.padding(toLength: 13, withPad: " ", startingAt: 0)
+
+                progressView.display(message: "║ \(id) │ \(status) │ \(hostname) │ \(lastSeenPadded) ║")
+            }
+
+            progressView.display(message: "╚══════════════════════════════════════╧══════════╧══════════════════╧═══════════════╝")
+            progressView.display(message: "")
+            progressView.display(message: "Legend: ● active, ○ pending, ◌ offline, ✗ rejected")
+            progressView.display(message: "Showing \(agents.count) agent(s)")
+        }
+
+        private func statusIcon(_ state: AgentConnectionState) -> String {
+            switch state {
+            case .active: return "● active"
+            case .pending: return "○ pending"
+            case .offline: return "◌ offline"
+            case .rejected: return "✗ reject"
+            case .disconnected: return "◌ discon"
+            }
+        }
+    }
+}
+
+// MARK: - FleetStatus Subcommand
+
+extension FleetCommand {
+    struct FleetStatus: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "status",
+            abstract: "Show fleet-wide status and statistics"
+        )
+
+        @Flag(name: .shortAndLong, help: "Show output in JSON format")
+        var json: Bool = false
+
+        mutating func run() async throws {
+            let progressView = ProgressView()
+            let registry = AgentRegistry()
+            let stats = await registry.statistics()
+
+            if json {
+                let encoder = JSONEncoder()
+                encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+                encoder.dateEncodingStrategy = .iso8601
+                let data = try encoder.encode(stats)
+                print(String(data: data, encoding: .utf8) ?? "{}")
+            } else {
+                printFleetStatus(stats, progressView: progressView)
+            }
+        }
+
+        private func printFleetStatus(_ stats: RegistryStatistics, progressView: ProgressView) {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+
+            progressView.display(message: "")
+            progressView.display(message: "═══════════════════════════════════════════════════════════")
+            progressView.display(message: "                     FLEET STATUS                          ")
+            progressView.display(message: "═══════════════════════════════════════════════════════════")
+            progressView.display(message: "")
+            progressView.display(message: "  Connection Status")
+            progressView.display(message: "  ─────────────────────────────────────────────────────────")
+            progressView.display(message: "    Total Agents:     \(stats.totalAgents)")
+            progressView.display(message: "    Active:           \(stats.activeAgents) ●")
+            progressView.display(message: "    Offline:          \(stats.offlineAgents) ◌")
+            progressView.display(message: "    Pending:          \(stats.pendingAgents) ○")
+            progressView.display(message: "")
+            progressView.display(message: "  Health Status")
+            progressView.display(message: "  ─────────────────────────────────────────────────────────")
+            progressView.display(message: "    Healthy:          \(stats.healthyAgents) ✓")
+            progressView.display(message: "    Warning:          \(stats.warningAgents) ⚠")
+            progressView.display(message: "    Critical:         \(stats.criticalAgents) ✗")
+            progressView.display(message: "")
+            progressView.display(message: "  Timestamp:          \(formatter.string(from: stats.timestamp))")
+            progressView.display(message: "")
+            progressView.display(message: "═══════════════════════════════════════════════════════════")
+        }
+    }
+}
+
+// MARK: - Deploy Subcommand
+
+extension FleetCommand {
+    struct Deploy: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "deploy",
+            abstract: "Deploy a policy to agents"
+        )
+
+        @Argument(help: "Policy name to deploy")
+        var policyName: String
+
+        @Flag(name: .long, help: "Deploy to all registered agents")
+        var all: Bool = false
+
+        @Option(name: .long, help: "Deploy to agents with specific tag")
+        var tag: String?
+
+        @Option(name: .long, help: "Deploy to specific agent IDs (comma-separated)")
+        var agents: String?
+
+        @Flag(name: .long, help: "Dry run - show what would be deployed")
+        var dryRun: Bool = false
+
+        @Flag(name: .shortAndLong, help: "Show output in JSON format")
+        var json: Bool = false
+
+        mutating func run() async throws {
+            let progressView = ProgressView()
+
+            // Validate target selection
+            if !all && tag == nil && agents == nil {
+                progressView.display(message: "✗ Please specify a target: --all, --tag, or --agents")
+                return
+            }
+
+            // Load policy
+            let store = try PolicyStore()
+            let policy: Policy
+            do {
+                policy = try store.get(policyName)
+            } catch {
+                progressView.display(message: "✗ Policy '\(policyName)' not found")
+                return
+            }
+
+            // Determine target
+            let target: DistributionTarget
+            if all {
+                target = .all
+            } else if let tagValue = tag {
+                target = .tags([tagValue])
+            } else if let agentIds = agents {
+                let ids = agentIds.split(separator: ",").compactMap { UUID(uuidString: String($0.trimmingCharacters(in: .whitespaces))) }
+                target = .agents(ids)
+            } else {
+                target = .all
+            }
+
+            let registry = AgentRegistry()
+            let distributor = PolicyDistributor(registry: registry)
+
+            if dryRun {
+                progressView.display(message: "Dry run - would deploy policy '\(policyName)' to:")
+
+                let targetAgents = await getTargetAgents(target: target, registry: registry)
+                for agent in targetAgents {
+                    progressView.display(message: "  - \(agent.identity.hostname) (\(agent.identity.id))")
+                }
+                progressView.display(message: "")
+                progressView.display(message: "Total: \(targetAgents.count) agent(s)")
+                return
+            }
+
+            progressView.display(message: "Deploying policy '\(policyName)'...")
+
+            do {
+                let status = try await distributor.distribute(policy: policy, to: target)
+
+                if json {
+                    let encoder = JSONEncoder()
+                    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+                    encoder.dateEncodingStrategy = .iso8601
+                    let data = try encoder.encode(status)
+                    print(String(data: data, encoding: .utf8) ?? "{}")
+                } else {
+                    progressView.display(message: "")
+                    progressView.displaySuccess("Policy deployment initiated")
+                    progressView.display(message: "  Distribution ID:  \(status.id)")
+                    progressView.display(message: "  Target Agents:    \(status.totalAgents)")
+                    progressView.display(message: "  Status:           \(status.state.rawValue)")
+                }
+            } catch {
+                progressView.display(message: "✗ Deployment failed: \(error.localizedDescription)")
+            }
+        }
+
+        private func getTargetAgents(target: DistributionTarget, registry: AgentRegistry) async -> [RegisteredAgent] {
+            switch target {
+            case .all:
+                return await registry.allAgents()
+            case .agents(let ids):
+                var result: [RegisteredAgent] = []
+                for id in ids {
+                    if let agent = await registry.agent(byId: id) {
+                        result.append(agent)
+                    }
+                }
+                return result
+            case .tags(let tags):
+                return await registry.agents(withTags: Array(tags))
+            case .capabilities(let caps):
+                var result: [RegisteredAgent] = []
+                for cap in caps {
+                    result.append(contentsOf: await registry.agents(withCapability: cap))
+                }
+                return Array(Set(result.map { $0.identity.id })).compactMap { id in
+                    result.first { $0.identity.id == id }
+                }
+            case .filter, .combined:
+                return await registry.allAgents()
+            }
+        }
+    }
+}
+
+// MARK: - Compliance Subcommand
+
+extension FleetCommand {
+    struct Compliance: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "compliance",
+            abstract: "Generate fleet compliance report"
+        )
+
+        @Option(name: .shortAndLong, help: "Export format (json, csv)")
+        var format: String = "text"
+
+        @Option(name: .shortAndLong, help: "Output file path")
+        var output: String?
+
+        mutating func run() async throws {
+            let progressView = ProgressView()
+            let registry = AgentRegistry()
+            let distributor = PolicyDistributor(registry: registry)
+            let reporter = ComplianceReporter(registry: registry, distributor: distributor)
+
+            progressView.display(message: "Generating compliance report...")
+
+            do {
+                let report = try await reporter.generateFleetOverview()
+
+                switch format.lowercased() {
+                case "json":
+                    let encoder = JSONEncoder()
+                    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+                    encoder.dateEncodingStrategy = .iso8601
+                    let data = try encoder.encode(report)
+                    let jsonString = String(data: data, encoding: .utf8) ?? "{}"
+
+                    if let outputPath = output {
+                        try jsonString.write(toFile: outputPath, atomically: true, encoding: String.Encoding.utf8)
+                        progressView.displaySuccess("Report exported to \(outputPath)")
+                    } else {
+                        print(jsonString)
+                    }
+
+                case "csv":
+                    let csv = generateCSV(from: report)
+                    if let outputPath = output {
+                        try csv.write(toFile: outputPath, atomically: true, encoding: String.Encoding.utf8)
+                        progressView.displaySuccess("Report exported to \(outputPath)")
+                    } else {
+                        print(csv)
+                    }
+
+                default:
+                    printComplianceReport(report, progressView: progressView)
+                }
+            } catch {
+                progressView.display(message: "✗ Failed to generate report: \(error.localizedDescription)")
+            }
+        }
+
+        private func printComplianceReport(_ report: FleetOverviewReport, progressView: ProgressView) {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+
+            let complianceRate = report.totalAgents > 0
+                ? Double(report.compliantAgents) / Double(report.totalAgents) * 100
+                : 0.0
+            let partiallyCompliant = report.complianceLevelBreakdown[.partiallyCompliant] ?? 0
+
+            progressView.display(message: "")
+            progressView.display(message: "═══════════════════════════════════════════════════════════")
+            progressView.display(message: "                  FLEET COMPLIANCE REPORT                  ")
+            progressView.display(message: "═══════════════════════════════════════════════════════════")
+            progressView.display(message: "")
+            progressView.display(message: "  Generated:        \(formatter.string(from: report.generatedAt))")
+            progressView.display(message: "")
+            progressView.display(message: "  Fleet Overview")
+            progressView.display(message: "  ─────────────────────────────────────────────────────────")
+            progressView.display(message: "    Total Agents:         \(report.totalAgents)")
+            progressView.display(message: "    Compliant:            \(report.compliantAgents) ✓")
+            progressView.display(message: "    Partially Compliant:  \(partiallyCompliant) ⚠")
+            progressView.display(message: "    Non-Compliant:        \(report.nonCompliantAgents) ✗")
+            progressView.display(message: "    Critical:             \(report.criticalAgents) ✗✗")
+            progressView.display(message: "")
+            progressView.display(message: "  Compliance Rate:        \(String(format: "%.1f", complianceRate))%")
+            progressView.display(message: "  Average Score:          \(String(format: "%.2f", report.averageComplianceScore))")
+            progressView.display(message: "")
+            progressView.display(message: "═══════════════════════════════════════════════════════════")
+        }
+
+        private func generateCSV(from report: FleetOverviewReport) -> String {
+            let complianceRate = report.totalAgents > 0
+                ? Double(report.compliantAgents) / Double(report.totalAgents) * 100
+                : 0.0
+            let partiallyCompliant = report.complianceLevelBreakdown[.partiallyCompliant] ?? 0
+
+            var lines = ["Metric,Value"]
+            lines.append("Total Agents,\(report.totalAgents)")
+            lines.append("Compliant,\(report.compliantAgents)")
+            lines.append("Partially Compliant,\(partiallyCompliant)")
+            lines.append("Non-Compliant,\(report.nonCompliantAgents)")
+            lines.append("Critical,\(report.criticalAgents)")
+            lines.append("Compliance Rate,\(String(format: "%.2f", complianceRate))%")
+            lines.append("Average Score,\(String(format: "%.2f", report.averageComplianceScore))")
+            return lines.joined(separator: "\n")
+        }
+    }
+}
+
+// MARK: - Audit Subcommand
+
+extension FleetCommand {
+    struct Audit: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "audit",
+            abstract: "Show fleet audit log summary"
+        )
+
+        @Option(name: .shortAndLong, help: "Number of days to include (default: 7)")
+        var days: Int = 7
+
+        @Option(name: .long, help: "Filter by category (cleanup, policy, security, system)")
+        var category: String?
+
+        @Flag(name: .shortAndLong, help: "Show output in JSON format")
+        var json: Bool = false
+
+        mutating func run() async throws {
+            let progressView = ProgressView()
+            let registry = AgentRegistry()
+            let distributor = PolicyDistributor(registry: registry)
+            let reporter = ComplianceReporter(registry: registry, distributor: distributor)
+
+            let periodEnd = Date()
+            let periodStart = Calendar.current.date(byAdding: .day, value: -days, to: periodEnd) ?? periodEnd
+
+            progressView.display(message: "Generating audit log summary...")
+
+            do {
+                let summary = try await reporter.generateAuditLogSummary(
+                    periodStart: periodStart,
+                    periodEnd: periodEnd
+                )
+
+                if json {
+                    let encoder = JSONEncoder()
+                    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+                    encoder.dateEncodingStrategy = .iso8601
+                    let data = try encoder.encode(summary)
+                    print(String(data: data, encoding: .utf8) ?? "{}")
+                } else {
+                    printAuditSummary(summary, progressView: progressView)
+                }
+            } catch {
+                progressView.display(message: "✗ Failed to generate audit summary: \(error.localizedDescription)")
+            }
+        }
+
+        private func printAuditSummary(_ summary: AuditLogSummary, progressView: ProgressView) {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+
+            progressView.display(message: "")
+            progressView.display(message: "═══════════════════════════════════════════════════════════")
+            progressView.display(message: "                    FLEET AUDIT SUMMARY                    ")
+            progressView.display(message: "═══════════════════════════════════════════════════════════")
+            progressView.display(message: "")
+            progressView.display(message: "  Period: \(formatter.string(from: summary.periodStart)) - \(formatter.string(from: summary.periodEnd))")
+            progressView.display(message: "  Total Entries: \(summary.totalEntries)")
+            progressView.display(message: "")
+            progressView.display(message: "  Entries by Category")
+            progressView.display(message: "  ─────────────────────────────────────────────────────────")
+
+            for (category, count) in summary.entriesByCategory.sorted(by: { $0.value > $1.value }) {
+                progressView.display(message: "    \(category.padding(toLength: 12, withPad: " ", startingAt: 0)): \(count)")
+            }
+
+            progressView.display(message: "")
+            progressView.display(message: "  Entries by Severity")
+            progressView.display(message: "  ─────────────────────────────────────────────────────────")
+
+            for (severity, count) in summary.entriesBySeverity.sorted(by: { $0.value > $1.value }) {
+                let icon: String
+                switch severity {
+                case .critical: icon = "✗✗"
+                case .error: icon = "✗"
+                case .warning: icon = "⚠"
+                case .info: icon = "ℹ"
+                }
+                progressView.display(message: "    \(icon) \(severity.rawValue.padding(toLength: 10, withPad: " ", startingAt: 0)): \(count)")
+            }
+
+            progressView.display(message: "")
+            progressView.display(message: "═══════════════════════════════════════════════════════════")
+        }
+    }
+}
+
+// MARK: - Helper Types
+
+private struct AgentSummary: Codable {
+    let id: UUID
+    let hostname: String
+    let connectionState: String
+    let healthStatus: String?
+    let lastHeartbeat: Date?
+    let tags: [String]
+
+    init(from agent: RegisteredAgent) {
+        self.id = agent.identity.id
+        self.hostname = agent.identity.hostname
+        self.connectionState = agent.connectionState.rawValue
+        self.healthStatus = agent.latestStatus?.healthStatus.rawValue
+        self.lastHeartbeat = agent.lastHeartbeat
+        self.tags = agent.identity.tags
+    }
+}

--- a/Sources/osxcleaner/Commands/ServerCommand.swift
+++ b/Sources/osxcleaner/Commands/ServerCommand.swift
@@ -1,0 +1,378 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+
+import ArgumentParser
+import Foundation
+import OSXCleanerKit
+
+struct ServerCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "server",
+        abstract: "Manage connection to central management server",
+        discussion: """
+            Connect this agent to a central OSX Cleaner management server for
+            fleet-wide policy management and monitoring.
+
+            Examples:
+              osxcleaner server status                    # Show connection status
+              osxcleaner server connect https://mgmt.example.com
+              osxcleaner server disconnect
+              osxcleaner server register --name "my-mac"
+            """,
+        subcommands: [
+            Status.self,
+            Connect.self,
+            Disconnect.self,
+            Register.self,
+            Heartbeat.self
+        ],
+        defaultSubcommand: Status.self
+    )
+}
+
+// MARK: - Status Subcommand
+
+extension ServerCommand {
+    struct Status: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "status",
+            abstract: "Show current server connection status"
+        )
+
+        @Flag(name: .shortAndLong, help: "Show output in JSON format")
+        var json: Bool = false
+
+        mutating func run() async throws {
+            let progressView = ProgressView()
+            let configService = ConfigurationService()
+            let config = try configService.load()
+
+            let status = ServerConnectionStatus(
+                serverURL: config.serverURL,
+                agentId: config.agentId,
+                isRegistered: config.agentId != nil,
+                lastHeartbeat: config.lastHeartbeat,
+                tokenExpiresAt: config.tokenExpiresAt
+            )
+
+            if json {
+                let encoder = JSONEncoder()
+                encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+                encoder.dateEncodingStrategy = .iso8601
+                let data = try encoder.encode(status)
+                print(String(data: data, encoding: .utf8) ?? "{}")
+            } else {
+                printStatus(status, progressView: progressView)
+            }
+        }
+
+        private func printStatus(_ status: ServerConnectionStatus, progressView: ProgressView) {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+
+            progressView.display(message: "")
+            progressView.display(message: "═══════════════════════════════════════════════════════════")
+            progressView.display(message: "                  SERVER CONNECTION STATUS                  ")
+            progressView.display(message: "═══════════════════════════════════════════════════════════")
+            progressView.display(message: "")
+
+            if let serverURL = status.serverURL {
+                progressView.display(message: "  Server URL:      \(serverURL)")
+            } else {
+                progressView.display(message: "  Server URL:      Not configured")
+            }
+
+            if let agentId = status.agentId {
+                progressView.display(message: "  Agent ID:        \(agentId)")
+                progressView.display(message: "  Registered:      ✓ Yes")
+            } else {
+                progressView.display(message: "  Agent ID:        -")
+                progressView.display(message: "  Registered:      ○ No")
+            }
+
+            if let lastHeartbeat = status.lastHeartbeat {
+                progressView.display(message: "  Last Heartbeat:  \(formatter.string(from: lastHeartbeat))")
+            } else {
+                progressView.display(message: "  Last Heartbeat:  Never")
+            }
+
+            if let tokenExpires = status.tokenExpiresAt {
+                let isExpired = tokenExpires < Date()
+                let expiryStr = formatter.string(from: tokenExpires)
+                if isExpired {
+                    progressView.display(message: "  Token Expires:   \(expiryStr) (EXPIRED)")
+                } else {
+                    progressView.display(message: "  Token Expires:   \(expiryStr)")
+                }
+            }
+
+            progressView.display(message: "")
+            progressView.display(message: "═══════════════════════════════════════════════════════════")
+        }
+    }
+}
+
+// MARK: - Connect Subcommand
+
+extension ServerCommand {
+    struct Connect: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "connect",
+            abstract: "Configure connection to a management server"
+        )
+
+        @Argument(help: "Server URL (e.g., https://mgmt.example.com)")
+        var serverURL: String
+
+        @Option(name: .shortAndLong, help: "Request timeout in seconds")
+        var timeout: Int = 30
+
+        mutating func run() async throws {
+            let progressView = ProgressView()
+
+            guard let url = URL(string: serverURL) else {
+                progressView.display(message: "✗ Invalid server URL: \(serverURL)")
+                return
+            }
+
+            let configService = ConfigurationService()
+            var config = try configService.load()
+            config.serverURL = serverURL
+            config.serverTimeout = timeout
+            try configService.save(config)
+
+            progressView.display(message: "")
+            progressView.displaySuccess("Server configured: \(url.absoluteString)")
+            progressView.display(message: "")
+            progressView.display(message: "Use 'osxcleaner server register' to register this agent with the server.")
+        }
+    }
+}
+
+// MARK: - Disconnect Subcommand
+
+extension ServerCommand {
+    struct Disconnect: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "disconnect",
+            abstract: "Disconnect from the management server"
+        )
+
+        @Flag(name: .shortAndLong, help: "Skip confirmation prompt")
+        var force: Bool = false
+
+        mutating func run() async throws {
+            let progressView = ProgressView()
+            let configService = ConfigurationService()
+            var config = try configService.load()
+
+            guard config.serverURL != nil else {
+                progressView.display(message: "Not connected to any server")
+                return
+            }
+
+            if !force {
+                progressView.display(message: "This will disconnect from the server and clear registration.")
+                progressView.display(message: "Use --force to confirm.")
+                return
+            }
+
+            // If registered, try to unregister first
+            if let serverURL = config.serverURL,
+               let url = URL(string: serverURL),
+               config.authToken != nil {
+                let clientConfig = ServerClientConfig(serverURL: url)
+                let client = ServerClient(config: clientConfig)
+
+                do {
+                    try await client.unregister()
+                    progressView.display(message: "Unregistered from server")
+                } catch {
+                    progressView.displayWarning("Could not unregister: \(error.localizedDescription)")
+                }
+            }
+
+            // Clear local configuration
+            config.serverURL = nil
+            config.agentId = nil
+            config.authToken = nil
+            config.tokenExpiresAt = nil
+            config.lastHeartbeat = nil
+            try configService.save(config)
+
+            progressView.display(message: "")
+            progressView.displaySuccess("Disconnected from server")
+        }
+    }
+}
+
+// MARK: - Register Subcommand
+
+extension ServerCommand {
+    struct Register: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "register",
+            abstract: "Register this agent with the configured server"
+        )
+
+        @Option(name: .shortAndLong, help: "Custom agent name (defaults to hostname)")
+        var name: String?
+
+        @Option(name: .long, help: "Agent tags (comma-separated)")
+        var tags: String?
+
+        @Flag(name: .shortAndLong, help: "Show output in JSON format")
+        var json: Bool = false
+
+        mutating func run() async throws {
+            let progressView = ProgressView()
+            let configService = ConfigurationService()
+            var config = try configService.load()
+
+            guard let serverURLString = config.serverURL,
+                  let serverURL = URL(string: serverURLString) else {
+                progressView.display(message: "✗ No server configured. Use 'osxcleaner server connect <url>' first.")
+                return
+            }
+
+            // Create agent identity
+            let hostname = name ?? ProcessInfo.processInfo.hostName
+            let tagList = tags?.split(separator: ",").map { String($0.trimmingCharacters(in: .whitespaces)) } ?? []
+
+            let identity = AgentIdentity(
+                id: config.agentId ?? UUID(),
+                hostname: hostname,
+                osVersion: ProcessInfo.processInfo.operatingSystemVersionString,
+                appVersion: "0.1.0",
+                tags: tagList
+            )
+
+            progressView.display(message: "Registering with server: \(serverURL.absoluteString)")
+            progressView.display(message: "")
+
+            let clientConfig = ServerClientConfig(
+                serverURL: serverURL,
+                requestTimeout: TimeInterval(config.serverTimeout ?? 30)
+            )
+            let client = ServerClient(config: clientConfig)
+
+            do {
+                let result = try await client.register(identity: identity)
+
+                if result.success {
+                    // Save registration info
+                    config.agentId = result.agentId
+                    config.authToken = result.authToken
+                    config.tokenExpiresAt = result.tokenExpiresAt
+                    config.lastHeartbeat = Date()
+                    try configService.save(config)
+
+                    if json {
+                        let output = RegistrationOutput(
+                            success: true,
+                            agentId: result.agentId,
+                            message: result.message
+                        )
+                        let encoder = JSONEncoder()
+                        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+                        let data = try encoder.encode(output)
+                        print(String(data: data, encoding: .utf8) ?? "{}")
+                    } else {
+                        progressView.displaySuccess("Agent registered successfully!")
+                        progressView.display(message: "")
+                        progressView.display(message: "  Agent ID:  \(result.agentId?.uuidString ?? "unknown")")
+                        if let message = result.message {
+                            progressView.display(message: "  Message:   \(message)")
+                        }
+                    }
+                } else {
+                    progressView.display(message: "✗ Registration failed: \(result.message ?? "Unknown error")")
+                }
+            } catch {
+                progressView.display(message: "✗ Registration error: \(error.localizedDescription)")
+            }
+        }
+    }
+}
+
+// MARK: - Heartbeat Subcommand
+
+extension ServerCommand {
+    struct Heartbeat: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "heartbeat",
+            abstract: "Send a heartbeat to the server manually"
+        )
+
+        @Flag(name: .shortAndLong, help: "Show output in JSON format")
+        var json: Bool = false
+
+        mutating func run() async throws {
+            let progressView = ProgressView()
+            let configService = ConfigurationService()
+            var config = try configService.load()
+
+            guard let serverURLString = config.serverURL,
+                  let serverURL = URL(string: serverURLString) else {
+                progressView.display(message: "✗ No server configured")
+                return
+            }
+
+            guard config.authToken != nil, config.agentId != nil else {
+                progressView.display(message: "✗ Agent not registered. Use 'osxcleaner server register' first.")
+                return
+            }
+
+            let clientConfig = ServerClientConfig(
+                serverURL: serverURL,
+                requestTimeout: TimeInterval(config.serverTimeout ?? 30)
+            )
+            let client = ServerClient(config: clientConfig)
+
+            // Create current status
+            let status = AgentStatus.current(
+                agentId: config.agentId!,
+                connectionState: .active
+            )
+
+            do {
+                let response = try await client.heartbeat(status: status)
+
+                config.lastHeartbeat = Date()
+                try configService.save(config)
+
+                if json {
+                    let encoder = JSONEncoder()
+                    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+                    encoder.dateEncodingStrategy = .iso8601
+                    let data = try encoder.encode(response)
+                    print(String(data: data, encoding: .utf8) ?? "{}")
+                } else {
+                    progressView.displaySuccess("Heartbeat sent successfully")
+                    if response.pendingCommands > 0 {
+                        progressView.display(message: "  Pending commands: \(response.pendingCommands)")
+                    }
+                    progressView.display(message: "  Next heartbeat in: \(Int(response.nextHeartbeat))s")
+                }
+            } catch {
+                progressView.display(message: "✗ Heartbeat failed: \(error.localizedDescription)")
+            }
+        }
+    }
+}
+
+// MARK: - Helper Types
+
+private struct ServerConnectionStatus: Codable {
+    let serverURL: String?
+    let agentId: UUID?
+    let isRegistered: Bool
+    let lastHeartbeat: Date?
+    let tokenExpiresAt: Date?
+}
+
+private struct RegistrationOutput: Codable {
+    let success: Bool
+    let agentId: UUID?
+    let message: String?
+}

--- a/Sources/osxcleaner/OSXCleaner.swift
+++ b/Sources/osxcleaner/OSXCleaner.swift
@@ -22,7 +22,9 @@ struct OSXCleaner: AsyncParsableCommand {
             AuditCommand.self,
             PolicyCommand.self,
             InteractiveCommand.self,
-            TeamCommand.self
+            TeamCommand.self,
+            ServerCommand.self,
+            FleetCommand.self
         ],
         defaultSubcommand: AnalyzeCommand.self
     )

--- a/Tests/OSXCleanerKitTests/ServerFleetCLITests.swift
+++ b/Tests/OSXCleanerKitTests/ServerFleetCLITests.swift
@@ -1,0 +1,325 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+
+import XCTest
+@testable import OSXCleanerKit
+
+final class ServerFleetCLITests: XCTestCase {
+
+    // MARK: - Test Fixtures
+
+    private var registry: AgentRegistry!
+    private var distributor: PolicyDistributor!
+
+    override func setUp() async throws {
+        registry = AgentRegistry()
+        distributor = PolicyDistributor(registry: registry)
+    }
+
+    // MARK: - AgentRegistry Tests for CLI
+
+    func testAgentRegistryStatistics() async throws {
+        let stats = await registry.statistics()
+
+        XCTAssertEqual(stats.totalAgents, 0)
+        XCTAssertEqual(stats.activeAgents, 0)
+        XCTAssertEqual(stats.offlineAgents, 0)
+        XCTAssertEqual(stats.pendingAgents, 0)
+    }
+
+    func testAgentRegistrationForCLI() async throws {
+        let identity = AgentIdentity(
+            id: UUID(),
+            hostname: "test-mac",
+            osVersion: "14.0",
+            appVersion: "0.1.0",
+            tags: ["test", "cli"]
+        )
+
+        let agent = try await registry.register(
+            identity: identity,
+            capabilities: ["cleanup", "monitor"]
+        )
+
+        XCTAssertEqual(agent.identity.hostname, "test-mac")
+        XCTAssertEqual(agent.connectionState, .active)
+        XCTAssertEqual(agent.capabilities.count, 2)
+
+        let stats = await registry.statistics()
+        XCTAssertEqual(stats.totalAgents, 1)
+        XCTAssertEqual(stats.activeAgents, 1)
+    }
+
+    func testAgentListingByState() async throws {
+        // Register multiple agents
+        for i in 0..<3 {
+            let identity = AgentIdentity(
+                id: UUID(),
+                hostname: "test-mac-\(i)",
+                osVersion: "14.0",
+                appVersion: "0.1.0",
+                tags: []
+            )
+            _ = try await registry.register(identity: identity, capabilities: [])
+        }
+
+        let allAgents = await registry.allAgents()
+        XCTAssertEqual(allAgents.count, 3)
+
+        let activeAgents = await registry.agents(withState: .active)
+        XCTAssertEqual(activeAgents.count, 3)
+
+        let offlineAgents = await registry.agents(withState: .offline)
+        XCTAssertEqual(offlineAgents.count, 0)
+    }
+
+    func testAgentListingByTag() async throws {
+        // Register agent with tags
+        let identity1 = AgentIdentity(
+            id: UUID(),
+            hostname: "prod-mac",
+            osVersion: "14.0",
+            appVersion: "0.1.0",
+            tags: ["production", "critical"]
+        )
+        _ = try await registry.register(identity: identity1, capabilities: [])
+
+        let identity2 = AgentIdentity(
+            id: UUID(),
+            hostname: "dev-mac",
+            osVersion: "14.0",
+            appVersion: "0.1.0",
+            tags: ["development"]
+        )
+        _ = try await registry.register(identity: identity2, capabilities: [])
+
+        let prodAgents = await registry.agents(withTags: ["production"])
+        XCTAssertEqual(prodAgents.count, 1)
+        XCTAssertEqual(prodAgents.first?.identity.hostname, "prod-mac")
+
+        let devAgents = await registry.agents(withTags: ["development"])
+        XCTAssertEqual(devAgents.count, 1)
+    }
+
+    // MARK: - Distribution Target Tests
+
+    func testDistributionTargetAll() async throws {
+        // Register agents
+        for i in 0..<5 {
+            let identity = AgentIdentity(
+                id: UUID(),
+                hostname: "mac-\(i)",
+                osVersion: "14.0",
+                appVersion: "0.1.0",
+                tags: []
+            )
+            _ = try await registry.register(identity: identity, capabilities: [])
+        }
+
+        let target = DistributionTarget.all
+        let allAgents = await registry.allAgents()
+        XCTAssertEqual(allAgents.count, 5)
+    }
+
+    func testDistributionTargetByAgentIds() async throws {
+        var agentIds: [UUID] = []
+
+        for i in 0..<3 {
+            let id = UUID()
+            agentIds.append(id)
+
+            let identity = AgentIdentity(
+                id: id,
+                hostname: "mac-\(i)",
+                osVersion: "14.0",
+                appVersion: "0.1.0",
+                tags: []
+            )
+            _ = try await registry.register(identity: identity, capabilities: [])
+        }
+
+        // Target specific agents
+        let targetIds = Array(agentIds.prefix(2))
+        let target = DistributionTarget.agents(targetIds)
+
+        if case .agents(let ids) = target {
+            XCTAssertEqual(ids.count, 2)
+        } else {
+            XCTFail("Target should be .agents")
+        }
+    }
+
+    func testDistributionTargetByTags() {
+        let target = DistributionTarget.tags(["production", "critical"])
+
+        if case .tags(let tags) = target {
+            XCTAssertEqual(tags.count, 2)
+            XCTAssertTrue(tags.contains("production"))
+            XCTAssertTrue(tags.contains("critical"))
+        } else {
+            XCTFail("Target should be .tags")
+        }
+    }
+
+    // MARK: - Compliance Reporter Tests for CLI
+
+    func testComplianceReporterInitialization() async throws {
+        let reporter = ComplianceReporter(registry: registry, distributor: distributor)
+        XCTAssertNotNil(reporter)
+    }
+
+    func testFleetOverviewReportGeneration() async throws {
+        // Register an agent first
+        let identity = AgentIdentity(
+            id: UUID(),
+            hostname: "test-mac",
+            osVersion: "14.0",
+            appVersion: "0.1.0",
+            tags: []
+        )
+        _ = try await registry.register(identity: identity, capabilities: [])
+
+        let reporter = ComplianceReporter(registry: registry, distributor: distributor)
+        let report = try await reporter.generateFleetOverview()
+
+        XCTAssertEqual(report.totalAgents, 1)
+        XCTAssertGreaterThanOrEqual(report.averageComplianceScore, 0)
+        XCTAssertLessThanOrEqual(report.averageComplianceScore, 100)
+        XCTAssertNotNil(report.generatedAt)
+    }
+
+    // MARK: - Agent Status Tests
+
+    func testAgentStatusCreation() {
+        let agentId = UUID()
+        let status = AgentStatus.current(
+            agentId: agentId,
+            connectionState: .active
+        )
+
+        XCTAssertEqual(status.agentId, agentId)
+        XCTAssertEqual(status.connectionState, .active)
+        XCTAssertTrue(status.isOnline)
+    }
+
+    func testAgentStatusHealthDetermination() {
+        let agentId = UUID()
+        let status = AgentStatus.current(
+            agentId: agentId,
+            connectionState: .active
+        )
+
+        // Health should be determined based on available disk space
+        XCTAssertTrue([.healthy, .warning, .critical, .unknown].contains(status.healthStatus))
+    }
+
+    // MARK: - HeartbeatResponse Tests
+
+    func testHeartbeatResponseDefaults() {
+        let response = HeartbeatResponse()
+
+        XCTAssertTrue(response.acknowledged)
+        XCTAssertEqual(response.pendingPolicies, 0)
+        XCTAssertEqual(response.pendingCommands, 0)
+        XCTAssertEqual(response.nextHeartbeat, 60)
+    }
+
+    func testHeartbeatResponseCustomValues() {
+        let response = HeartbeatResponse(
+            acknowledged: true,
+            pendingPolicies: 3,
+            pendingCommands: 2,
+            nextHeartbeat: 120
+        )
+
+        XCTAssertTrue(response.acknowledged)
+        XCTAssertEqual(response.pendingPolicies, 3)
+        XCTAssertEqual(response.pendingCommands, 2)
+        XCTAssertEqual(response.nextHeartbeat, 120)
+    }
+
+    // MARK: - ServerClientConfig Tests
+
+    func testServerClientConfigDefaults() {
+        let url = URL(string: "https://mgmt.example.com")!
+        let config = ServerClientConfig(serverURL: url)
+
+        XCTAssertEqual(config.serverURL, url)
+        XCTAssertEqual(config.requestTimeout, 30)
+        XCTAssertEqual(config.heartbeatInterval, 60)
+        XCTAssertEqual(config.maxRetryAttempts, 3)
+        XCTAssertTrue(config.autoReconnect)
+    }
+
+    func testServerClientConfigCustomValues() {
+        let url = URL(string: "https://mgmt.example.com")!
+        let config = ServerClientConfig(
+            serverURL: url,
+            requestTimeout: 60,
+            heartbeatInterval: 120,
+            maxRetryAttempts: 5,
+            retryDelay: 10,
+            autoReconnect: false,
+            certificatePinning: true
+        )
+
+        XCTAssertEqual(config.requestTimeout, 60)
+        XCTAssertEqual(config.heartbeatInterval, 120)
+        XCTAssertEqual(config.maxRetryAttempts, 5)
+        XCTAssertEqual(config.retryDelay, 10)
+        XCTAssertFalse(config.autoReconnect)
+        XCTAssertTrue(config.certificatePinning)
+    }
+
+    // MARK: - AppConfiguration Server Settings Tests
+
+    func testAppConfigurationServerSettings() {
+        var config = AppConfiguration()
+
+        XCTAssertNil(config.serverURL)
+        XCTAssertNil(config.agentId)
+        XCTAssertNil(config.authToken)
+
+        config.serverURL = "https://mgmt.example.com"
+        config.agentId = UUID()
+        config.authToken = "test-token"
+        config.serverTimeout = 60
+        config.lastHeartbeat = Date()
+
+        XCTAssertEqual(config.serverURL, "https://mgmt.example.com")
+        XCTAssertNotNil(config.agentId)
+        XCTAssertEqual(config.authToken, "test-token")
+        XCTAssertEqual(config.serverTimeout, 60)
+        XCTAssertNotNil(config.lastHeartbeat)
+    }
+
+    // MARK: - RegistryStatistics Tests
+
+    func testRegistryStatisticsCalculation() async throws {
+        // Register agents with different states
+        let identity1 = AgentIdentity(
+            id: UUID(),
+            hostname: "active-mac",
+            osVersion: "14.0",
+            appVersion: "0.1.0",
+            tags: []
+        )
+        _ = try await registry.register(identity: identity1, capabilities: [])
+
+        let identity2 = AgentIdentity(
+            id: UUID(),
+            hostname: "offline-mac",
+            osVersion: "14.0",
+            appVersion: "0.1.0",
+            tags: []
+        )
+        let agent2 = try await registry.register(identity: identity2, capabilities: [])
+        try await registry.markOffline(agentId: agent2.identity.id)
+
+        let stats = await registry.statistics()
+
+        XCTAssertEqual(stats.totalAgents, 2)
+        XCTAssertEqual(stats.activeAgents, 1)
+        XCTAssertEqual(stats.offlineAgents, 1)
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Reduce total lint violations from 87 to 29 (all warnings, no errors)
 
 ### Added
+- **F14-6: Server & Fleet CLI Commands** (#115)
+  - ServerCommand for agent-side server connection management:
+    - `server status`: Display current server connection status
+    - `server connect <url>`: Configure connection to management server
+    - `server disconnect`: Disconnect and clear registration
+    - `server register`: Register agent with the configured server
+    - `server heartbeat`: Send manual heartbeat to server
+  - FleetCommand for administrator-side fleet management:
+    - `fleet agents`: List all registered agents with filtering by state, tag, or capability
+    - `fleet status`: Show fleet-wide statistics and health overview
+    - `fleet deploy <policy>`: Deploy policies to agents with target selection (--all, --tag, --agents)
+    - `fleet compliance`: Generate fleet compliance report with export to JSON/CSV
+    - `fleet audit`: Show audit log summary for configurable time periods
+  - AppConfiguration extended with server connection settings:
+    - serverURL, serverTimeout, agentId, authToken, tokenExpiresAt, lastHeartbeat
+  - JSON output support for all commands (--json flag)
+  - 17 comprehensive unit tests for CLI-related functionality
+
 - **F14-5: Role-Based Access Control (RBAC)** (#127)
   - Role enum with three-tier hierarchy:
     - Admin: Full access to all features including user management


### PR DESCRIPTION
## Summary

- Add ServerCommand for agent-side server connection management
- Add FleetCommand for administrator-side fleet management
- Extend AppConfiguration with server connection settings
- Add 17 comprehensive unit tests

### ServerCommand Subcommands
- `server status`: Display current server connection status
- `server connect <url>`: Configure connection to management server
- `server disconnect`: Disconnect and clear registration
- `server register`: Register agent with the configured server
- `server heartbeat`: Send manual heartbeat to server

### FleetCommand Subcommands
- `fleet agents`: List registered agents with filtering options (state, tag, capability)
- `fleet status`: Show fleet-wide statistics and health overview
- `fleet deploy <policy>`: Deploy policies with flexible targeting (--all, --tag, --agents)
- `fleet compliance`: Generate compliance reports with export to JSON/CSV
- `fleet audit`: Show audit log summary for configurable time periods

### Features
- JSON output support for all commands (--json flag)
- Dry-run mode for policy deployment
- Progress display with formatted tables

## Test plan

- [x] Build succeeds without errors
- [x] All 17 new unit tests pass
- [x] Manual verification of CLI help output
- [x] Integration with existing server components verified

Closes #115