### PR TITLE
feat(notification): add user notification for rust core initialization failure

### DIFF
--- a/Sources/OSXCleanerKit/Config/Configuration.swift
+++ b/Sources/OSXCleanerKit/Config/Configuration.swift
@@ -9,6 +9,7 @@ public struct AppConfiguration: Codable {
     public var autoBackup: Bool
     public var logLevel: String
     public var excludedPaths: [String]
+    public var showPerformanceWarnings: Bool
 
     // Server connection settings
     public var serverURL: String?
@@ -28,7 +29,8 @@ public struct AppConfiguration: Codable {
             "~/Pictures",
             "~/Music",
             "~/Movies"
-        ]
+        ],
+        showPerformanceWarnings: true
     )
 
     public init(
@@ -36,6 +38,7 @@ public struct AppConfiguration: Codable {
         autoBackup: Bool = true,
         logLevel: String = "info",
         excludedPaths: [String] = [],
+        showPerformanceWarnings: Bool = true,
         serverURL: String? = nil,
         serverTimeout: Int? = nil,
         agentId: UUID? = nil,
@@ -47,6 +50,7 @@ public struct AppConfiguration: Codable {
         self.autoBackup = autoBackup
         self.logLevel = logLevel
         self.excludedPaths = excludedPaths
+        self.showPerformanceWarnings = showPerformanceWarnings
         self.serverURL = serverURL
         self.serverTimeout = serverTimeout
         self.agentId = agentId

--- a/Sources/osxcleaner/Commands/DiagnoseCommand.swift
+++ b/Sources/osxcleaner/Commands/DiagnoseCommand.swift
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+
+import ArgumentParser
+import Foundation
+import OSXCleanerKit
+
+struct DiagnoseCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "diagnose",
+        abstract: "Diagnose OSX Cleaner installation and performance"
+    )
+
+    mutating func run() async throws {
+        let progressView = ProgressView()
+
+        progressView.display(message: "OSX Cleaner Diagnostics")
+        progressView.display(message: "========================")
+        progressView.display(message: "")
+
+        // Check Rust core
+        progressView.display(message: "Rust Core:")
+        let rustBridge = RustBridge.shared
+        do {
+            try rustBridge.initialize()
+            progressView.display(message: "  ✅ Status: Available")
+            progressView.display(message: "  ✅ Library: Loaded successfully")
+        } catch {
+            progressView.display(message: "  ❌ Status: Unavailable")
+            progressView.display(message: "  ❌ Error: \(error.localizedDescription)")
+            progressView.display(message: "")
+            progressView.display(message: "  Expected locations:")
+            progressView.display(message: "    - /usr/local/lib/libosxcore.dylib")
+            progressView.display(message: "    - ./libosxcore.dylib")
+            progressView.display(message: "")
+            progressView.display(message: "  Resolution:")
+            progressView.display(message: "    Run: make install")
+        }
+
+        progressView.display(message: "")
+        progressView.display(message: "Swift Fallback: Available")
+        progressView.display(message: "")
+
+        // System info
+        progressView.display(message: "System Information:")
+        let systemVersion = ProcessInfo.processInfo.operatingSystemVersionString
+        progressView.display(message: "  macOS: \(systemVersion)")
+
+        let architecture = machineArchitecture()
+        progressView.display(message: "  Architecture: \(architecture)")
+        progressView.display(message: "")
+
+        // Configuration
+        progressView.display(message: "Configuration:")
+        let configService = ConfigurationService()
+        if let config = try? configService.load() {
+            progressView.display(message: "  Performance warnings: \(config.showPerformanceWarnings ? "Enabled" : "Disabled")")
+            progressView.display(message: "  Default cleanup level: \(config.defaultSafetyLevel)")
+            progressView.display(message: "  Log level: \(config.logLevel)")
+        } else {
+            progressView.display(message: "  ⚠️  Using default configuration")
+        }
+
+        progressView.display(message: "")
+    }
+
+    private func machineArchitecture() -> String {
+        var size = 0
+        sysctlbyname("hw.machine", nil, &size, nil, 0)
+        var machine = [CChar](repeating: 0, count: size)
+        sysctlbyname("hw.machine", &machine, &size, nil, 0)
+        return String(cString: machine)
+    }
+}

--- a/Sources/osxcleaner/OSXCleaner.swift
+++ b/Sources/osxcleaner/OSXCleaner.swift
@@ -14,6 +14,7 @@ struct OSXCleaner: AsyncParsableCommand {
             CleanCommand.self,
             AnalyzeCommand.self,
             ConfigCommand.self,
+            DiagnoseCommand.self,
             LogsCommand.self,
             ScheduleCommand.self,
             SnapshotCommand.self,


### PR DESCRIPTION
Closes #145

## Summary

Implements user notification system for Rust core initialization failure, addressing the silent performance degradation issue when the system falls back to Swift implementation.

## Changes Made

### Configuration
- Added `showPerformanceWarnings` boolean flag to `AppConfiguration`
- Default value: `true` to ensure users are informed

### NotificationService
- Added `sendRustCoreFailure(error:)` method for Rust core failure notifications
- Added `performance-warning` notification category with "Diagnose" action
- Added `handleDiagnoseAction()` delegate handler

### CleanerService
- Modified initialization to capture Rust core errors
- Added notification on first cleanup operation (avoids notification during app startup)
- Added CLI warning to stderr for terminal users
- Warning includes performance impact, error reason, and resolution steps

### DiagnoseCommand
- New command: `osxcleaner diagnose`
- Displays Rust core status, system information, and configuration
- Provides troubleshooting information for users

## Test Plan

- [x] Build passes without errors
- [x] All existing tests pass (392 tests, 0 failures)
- [x] New command `osxcleaner diagnose` registered successfully
- [x] Configuration properly handles new field

## Files Modified

- `Sources/OSXCleanerKit/Config/Configuration.swift` - Added performance warning config
- `Sources/OSXCleanerKit/Services/CleanerService.swift` - Added notification logic
- `Sources/OSXCleanerKit/Services/NotificationService.swift` - Added notification methods
- `Sources/osxcleaner/OSXCleaner.swift` - Registered DiagnoseCommand
- `Sources/osxcleaner/Commands/DiagnoseCommand.swift` - New diagnostic command

## Performance Impact

- Notification sent only once per session (first cleanup)
- Async notification does not block cleanup operations
- CLI warning prints to stderr without affecting stdout