### PR TITLE
feat(validation): implement ConfigValidator module

### DIFF
--- a/Sources/OSXCleanerKit/Validation/ConfigValidator.swift
+++ b/Sources/OSXCleanerKit/Validation/ConfigValidator.swift
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+
+import Foundation
+
+/// Validates CleanerConfiguration settings to ensure valid cleanup levels,
+/// paths, and configuration consistency
+public struct ConfigValidator {
+    // MARK: - Main Validation
+
+    /// Validates a CleanerConfiguration instance
+    ///
+    /// This method performs comprehensive configuration validation including:
+    /// - Cleanup level range validation (1-4)
+    /// - Custom path validation using PathValidator
+    /// - Conflicting options detection
+    ///
+    /// - Parameter config: The CleanerConfiguration to validate
+    /// - Throws: ValidationError if validation fails
+    public static func validate(_ config: CleanerConfiguration) throws {
+        // 1. Validate cleanup level (1-4)
+        try validateCleanupLevel(config.cleanupLevel)
+
+        // 2. Validate specific paths
+        if !config.specificPaths.isEmpty {
+            try validatePaths(config.specificPaths)
+        }
+
+        // 3. Check for conflicting options
+        try checkConflictingOptions(config)
+    }
+
+    /// Validates an MDM configuration
+    ///
+    /// - Parameter config: The MDM configuration to validate
+    /// - Throws: ValidationError if validation fails
+    public static func validate(_ config: MDMConfiguration) throws {
+        // 1. Validate server URL uses HTTPS
+        guard config.serverURL.scheme == "https" else {
+            throw ValidationError.insecureMDMURL
+        }
+
+        // 2. Validate sync interval is positive
+        guard config.syncInterval > 0 else {
+            throw ValidationError.invalidCheckInterval(Int(config.syncInterval))
+        }
+
+        // 3. Validate request timeout is positive
+        guard config.requestTimeout > 0 else {
+            throw ValidationError.invalidCheckInterval(Int(config.requestTimeout))
+        }
+    }
+
+    // MARK: - Individual Validation Methods
+
+    /// Validates cleanup level is in valid range (1-4)
+    ///
+    /// - Parameter level: The cleanup level to validate
+    /// - Throws: ValidationError.invalidCleanupLevel if level is out of range
+    private static func validateCleanupLevel(_ level: CleanupLevel) throws {
+        let rawValue = level.rawValue
+        guard (1...4).contains(rawValue) else {
+            throw ValidationError.invalidCleanupLevel(rawValue)
+        }
+    }
+
+    /// Validates an array of paths using PathValidator
+    ///
+    /// - Parameter paths: Array of path strings to validate
+    /// - Throws: ValidationError if any path is invalid
+    private static func validatePaths(_ paths: [String]) throws {
+        // Use PathValidator with lenient options (don't require existence)
+        let options = PathValidator.ValidationOptions.lenient
+        _ = try PathValidator.validateAll(paths, options: options)
+    }
+
+    /// Checks for conflicting configuration options
+    ///
+    /// - Parameter config: The configuration to check
+    /// - Throws: ValidationError.conflictingOptions if conflicts are detected
+    private static func checkConflictingOptions(_ config: CleanerConfiguration) throws {
+        // Cannot use system-level cleanup with dry run
+        // (system cleanup is typically more dangerous and requires explicit execution)
+        if config.cleanupLevel == .system && config.dryRun {
+            throw ValidationError.conflictingOptions(
+                "System-level cleanup should not be used with dry-run mode"
+            )
+        }
+    }
+
+    // MARK: - Batch Validation
+
+    /// Validates multiple CleanerConfiguration instances
+    ///
+    /// - Parameter configs: Array of configurations to validate
+    /// - Throws: ValidationError for the first invalid configuration
+    public static func validateAll(_ configs: [CleanerConfiguration]) throws {
+        for config in configs {
+            try validate(config)
+        }
+    }
+
+    /// Validates multiple CleanerConfiguration instances, collecting all errors
+    ///
+    /// - Parameter configs: Array of configurations to validate
+    /// - Returns: Array of validation errors (empty if all valid)
+    public static func validateAllWithErrors(
+        _ configs: [CleanerConfiguration]
+    ) -> [ValidationError] {
+        var errors: [ValidationError] = []
+
+        for config in configs {
+            do {
+                try validate(config)
+            } catch let error as ValidationError {
+                errors.append(error)
+            } catch {
+                // Unexpected error, wrap it
+                errors.append(.invalidFFIString(error.localizedDescription))
+            }
+        }
+
+        return errors
+    }
+}

--- a/Tests/OSXCleanerKitTests/ConfigValidatorTests.swift
+++ b/Tests/OSXCleanerKitTests/ConfigValidatorTests.swift
@@ -1,0 +1,368 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+
+import XCTest
+@testable import OSXCleanerKit
+
+final class ConfigValidatorTests: XCTestCase {
+    // MARK: - Cleanup Level Validation Tests
+
+    func testValidateConfig_ValidLightLevel_Succeeds() throws {
+        // Given: Valid configuration with light cleanup level
+        let config = CleanerConfiguration(
+            cleanupLevel: .light,
+            dryRun: false
+        )
+
+        // When/Then: Validation should succeed
+        XCTAssertNoThrow(try ConfigValidator.validate(config))
+    }
+
+    func testValidateConfig_ValidNormalLevel_Succeeds() throws {
+        // Given: Valid configuration with normal cleanup level
+        let config = CleanerConfiguration(
+            cleanupLevel: .normal,
+            dryRun: false
+        )
+
+        // When/Then: Validation should succeed
+        XCTAssertNoThrow(try ConfigValidator.validate(config))
+    }
+
+    func testValidateConfig_ValidDeepLevel_Succeeds() throws {
+        // Given: Valid configuration with deep cleanup level
+        let config = CleanerConfiguration(
+            cleanupLevel: .deep,
+            dryRun: false
+        )
+
+        // When/Then: Validation should succeed
+        XCTAssertNoThrow(try ConfigValidator.validate(config))
+    }
+
+    func testValidateConfig_ValidSystemLevel_Succeeds() throws {
+        // Given: Valid configuration with system cleanup level (not dry-run)
+        let config = CleanerConfiguration(
+            cleanupLevel: .system,
+            dryRun: false
+        )
+
+        // When/Then: Validation should succeed
+        XCTAssertNoThrow(try ConfigValidator.validate(config))
+    }
+
+    // MARK: - Path Validation Tests
+
+    func testValidateConfig_EmptyPaths_Succeeds() throws {
+        // Given: Configuration with no specific paths
+        let config = CleanerConfiguration(
+            cleanupLevel: .normal,
+            specificPaths: []
+        )
+
+        // When/Then: Validation should succeed
+        XCTAssertNoThrow(try ConfigValidator.validate(config))
+    }
+
+    func testValidateConfig_ValidPaths_Succeeds() throws {
+        // Given: Configuration with valid specific paths
+        let config = CleanerConfiguration(
+            cleanupLevel: .normal,
+            specificPaths: [
+                "~/Library/Caches",
+                "/tmp"
+            ]
+        )
+
+        // When/Then: Validation should succeed
+        XCTAssertNoThrow(try ConfigValidator.validate(config))
+    }
+
+    func testValidateConfig_InvalidPath_ThrowsError() throws {
+        // Given: Configuration with invalid path (empty)
+        let config = CleanerConfiguration(
+            cleanupLevel: .normal,
+            specificPaths: [""]
+        )
+
+        // When/Then: Validation should throw emptyPath error
+        XCTAssertThrowsError(try ConfigValidator.validate(config)) { error in
+            guard let validationError = error as? ValidationError else {
+                XCTFail("Expected ValidationError")
+                return
+            }
+            if case .emptyPath = validationError {
+                // Expected error
+            } else {
+                XCTFail("Expected emptyPath error, got \(validationError)")
+            }
+        }
+    }
+
+    func testValidateConfig_PathWithNullByte_ThrowsError() throws {
+        // Given: Configuration with path containing null byte
+        let config = CleanerConfiguration(
+            cleanupLevel: .normal,
+            specificPaths: ["/tmp/test\0"]
+        )
+
+        // When/Then: Validation should throw nullByteInPath error
+        XCTAssertThrowsError(try ConfigValidator.validate(config)) { error in
+            guard let validationError = error as? ValidationError else {
+                XCTFail("Expected ValidationError")
+                return
+            }
+            if case .nullByteInPath = validationError {
+                // Expected error
+            } else {
+                XCTFail("Expected nullByteInPath error, got \(validationError)")
+            }
+        }
+    }
+
+    func testValidateConfig_TooLongPath_ThrowsError() throws {
+        // Given: Configuration with path exceeding maximum length
+        let longPath = String(repeating: "a", count: PathValidator.maximumPathLength + 1)
+        let config = CleanerConfiguration(
+            cleanupLevel: .normal,
+            specificPaths: [longPath]
+        )
+
+        // When/Then: Validation should throw pathTooLong error
+        XCTAssertThrowsError(try ConfigValidator.validate(config)) { error in
+            guard let validationError = error as? ValidationError else {
+                XCTFail("Expected ValidationError")
+                return
+            }
+            if case .pathTooLong = validationError {
+                // Expected error
+            } else {
+                XCTFail("Expected pathTooLong error, got \(validationError)")
+            }
+        }
+    }
+
+    // MARK: - Conflicting Options Tests
+
+    func testValidateConfig_SystemLevelWithDryRun_ThrowsError() throws {
+        // Given: Configuration with system level and dry-run (conflicting)
+        let config = CleanerConfiguration(
+            cleanupLevel: .system,
+            dryRun: true
+        )
+
+        // When/Then: Validation should throw conflictingOptions error
+        XCTAssertThrowsError(try ConfigValidator.validate(config)) { error in
+            guard let validationError = error as? ValidationError else {
+                XCTFail("Expected ValidationError")
+                return
+            }
+            if case .conflictingOptions = validationError {
+                // Expected error
+            } else {
+                XCTFail("Expected conflictingOptions error, got \(validationError)")
+            }
+        }
+    }
+
+    func testValidateConfig_NormalLevelWithDryRun_Succeeds() throws {
+        // Given: Configuration with normal level and dry-run (allowed)
+        let config = CleanerConfiguration(
+            cleanupLevel: .normal,
+            dryRun: true
+        )
+
+        // When/Then: Validation should succeed
+        XCTAssertNoThrow(try ConfigValidator.validate(config))
+    }
+
+    // MARK: - MDM Configuration Tests
+
+    func testValidateMDMConfig_ValidHTTPS_Succeeds() throws {
+        // Given: Valid MDM configuration with HTTPS URL
+        let config = MDMConfiguration(
+            provider: .jamf,
+            serverURL: URL(string: "https://example.com")!,
+            requestTimeout: 30,
+            syncInterval: 300,
+            autoSync: true,
+            autoReportStatus: true
+        )
+
+        // When/Then: Validation should succeed
+        XCTAssertNoThrow(try ConfigValidator.validate(config))
+    }
+
+    func testValidateMDMConfig_InsecureHTTP_ThrowsError() throws {
+        // Given: MDM configuration with HTTP URL (insecure)
+        let config = MDMConfiguration(
+            provider: .jamf,
+            serverURL: URL(string: "http://example.com")!,
+            requestTimeout: 30,
+            syncInterval: 300,
+            autoSync: true,
+            autoReportStatus: true
+        )
+
+        // When/Then: Validation should throw insecureMDMURL error
+        XCTAssertThrowsError(try ConfigValidator.validate(config)) { error in
+            guard let validationError = error as? ValidationError else {
+                XCTFail("Expected ValidationError")
+                return
+            }
+            if case .insecureMDMURL = validationError {
+                // Expected error
+            } else {
+                XCTFail("Expected insecureMDMURL error, got \(validationError)")
+            }
+        }
+    }
+
+    func testValidateMDMConfig_NegativeSyncInterval_ThrowsError() throws {
+        // Given: MDM configuration with negative sync interval
+        let config = MDMConfiguration(
+            provider: .jamf,
+            serverURL: URL(string: "https://example.com")!,
+            requestTimeout: 30,
+            syncInterval: -1,
+            autoSync: true,
+            autoReportStatus: true
+        )
+
+        // When/Then: Validation should throw invalidCheckInterval error
+        XCTAssertThrowsError(try ConfigValidator.validate(config)) { error in
+            guard let validationError = error as? ValidationError else {
+                XCTFail("Expected ValidationError")
+                return
+            }
+            if case .invalidCheckInterval = validationError {
+                // Expected error
+            } else {
+                XCTFail("Expected invalidCheckInterval error, got \(validationError)")
+            }
+        }
+    }
+
+    func testValidateMDMConfig_ZeroSyncInterval_ThrowsError() throws {
+        // Given: MDM configuration with zero sync interval
+        let config = MDMConfiguration(
+            provider: .jamf,
+            serverURL: URL(string: "https://example.com")!,
+            requestTimeout: 30,
+            syncInterval: 0,
+            autoSync: true,
+            autoReportStatus: true
+        )
+
+        // When/Then: Validation should throw invalidCheckInterval error
+        XCTAssertThrowsError(try ConfigValidator.validate(config)) { error in
+            guard let validationError = error as? ValidationError else {
+                XCTFail("Expected ValidationError")
+                return
+            }
+            if case .invalidCheckInterval = validationError {
+                // Expected error
+            } else {
+                XCTFail("Expected invalidCheckInterval error, got \(validationError)")
+            }
+        }
+    }
+
+    func testValidateMDMConfig_NegativeRequestTimeout_ThrowsError() throws {
+        // Given: MDM configuration with negative request timeout
+        let config = MDMConfiguration(
+            provider: .jamf,
+            serverURL: URL(string: "https://example.com")!,
+            requestTimeout: -1,
+            syncInterval: 300,
+            autoSync: true,
+            autoReportStatus: true
+        )
+
+        // When/Then: Validation should throw invalidCheckInterval error
+        XCTAssertThrowsError(try ConfigValidator.validate(config)) { error in
+            guard let validationError = error as? ValidationError else {
+                XCTFail("Expected ValidationError")
+                return
+            }
+            if case .invalidCheckInterval = validationError {
+                // Expected error
+            } else {
+                XCTFail("Expected invalidCheckInterval error, got \(validationError)")
+            }
+        }
+    }
+
+    // MARK: - Batch Validation Tests
+
+    func testValidateAll_AllValid_Succeeds() throws {
+        // Given: Array of all valid configurations
+        let configs = [
+            CleanerConfiguration(cleanupLevel: .light, dryRun: false),
+            CleanerConfiguration(cleanupLevel: .normal, dryRun: true),
+            CleanerConfiguration(cleanupLevel: .deep, dryRun: false)
+        ]
+
+        // When/Then: Validation should succeed
+        XCTAssertNoThrow(try ConfigValidator.validateAll(configs))
+    }
+
+    func testValidateAll_OneInvalid_ThrowsError() throws {
+        // Given: Array with one invalid configuration
+        let configs = [
+            CleanerConfiguration(cleanupLevel: .light, dryRun: false),
+            CleanerConfiguration(cleanupLevel: .system, dryRun: true),  // Invalid
+            CleanerConfiguration(cleanupLevel: .deep, dryRun: false)
+        ]
+
+        // When/Then: Validation should throw error for first invalid config
+        XCTAssertThrowsError(try ConfigValidator.validateAll(configs))
+    }
+
+    func testValidateAllWithErrors_CollectsAllErrors() throws {
+        // Given: Array with multiple invalid configurations
+        let configs = [
+            CleanerConfiguration(cleanupLevel: .light, dryRun: false),  // Valid
+            CleanerConfiguration(cleanupLevel: .system, dryRun: true),  // Invalid
+            CleanerConfiguration(
+                cleanupLevel: .normal,
+                specificPaths: [""]  // Invalid path
+            )
+        ]
+
+        // When: Validate all with error collection
+        let errors = ConfigValidator.validateAllWithErrors(configs)
+
+        // Then: Should collect 2 errors
+        XCTAssertEqual(errors.count, 2)
+
+        // First error should be conflictingOptions
+        if case .conflictingOptions = errors[0] {
+            // Expected
+        } else {
+            XCTFail("Expected conflictingOptions as first error")
+        }
+
+        // Second error should be emptyPath
+        if case .emptyPath = errors[1] {
+            // Expected
+        } else {
+            XCTFail("Expected emptyPath as second error")
+        }
+    }
+
+    func testValidateAllWithErrors_NoErrors_ReturnsEmpty() throws {
+        // Given: Array of all valid configurations
+        let configs = [
+            CleanerConfiguration(cleanupLevel: .light, dryRun: false),
+            CleanerConfiguration(cleanupLevel: .normal, dryRun: true),
+            CleanerConfiguration(cleanupLevel: .deep, dryRun: false)
+        ]
+
+        // When: Validate all with error collection
+        let errors = ConfigValidator.validateAllWithErrors(configs)
+
+        // Then: Should have no errors
+        XCTAssertTrue(errors.isEmpty)
+    }
+}


### PR DESCRIPTION
Closes #178

## Summary

Implemented ConfigValidator module to validate CleanerConfiguration and MDMConfiguration settings. This module ensures that all configurations are valid before being used, preventing invalid states and potential crashes.

### Key Features

- **Cleanup Level Validation**: Validates that cleanup levels are within the valid range (1-4)
- **Path Validation**: Validates custom paths using PathValidator to ensure path safety
- **Conflict Detection**: Detects conflicting options (e.g., system-level cleanup with dry-run)
- **MDM Validation**: Validates MDM configurations including HTTPS enforcement and interval checks
- **Batch Validation**: Supports validating multiple configurations at once with error collection

## Implementation Details

### ConfigValidator.swift
- `validate(_: CleanerConfiguration)`: Main validation method for cleaner configurations
- `validate(_: MDMConfiguration)`: Validation method for MDM configurations
- `validateAll(_:)`: Batch validation that stops at first error
- `validateAllWithErrors(_:)`: Batch validation that collects all errors

### Validation Rules

1. **Cleanup Level**: Must be in range 1-4 (light, normal, deep, system)
2. **Paths**: All custom paths must be valid according to PathValidator rules
3. **Conflicting Options**: System-level cleanup cannot be used with dry-run mode
4. **MDM URL**: Must use HTTPS protocol (security requirement)
5. **MDM Intervals**: Sync interval and request timeout must be positive

## Test Coverage

Added comprehensive test suite with 20 unit tests covering:
- All cleanup levels (light, normal, deep, system)
- Valid and invalid paths (empty, null bytes, too long)
- Conflicting options detection
- MDM configuration validation (HTTPS, intervals)
- Batch validation (success and error cases)

**Test Results**: 20/20 tests passed (100% pass rate)

## Files Changed

| File | Lines | Description |
|------|-------|-------------|
| `Sources/OSXCleanerKit/Validation/ConfigValidator.swift` | 126 | Main validator implementation |
| `Tests/OSXCleanerKitTests/ConfigValidatorTests.swift` | 367 | Comprehensive unit tests |

## Dependencies

- Depends on PathValidator (#177) - Already merged
- Part of Input Validation feature (#168)

## Test Plan

1. Build the project: `swift build` - Success
2. Run tests: `swift test --filter ConfigValidatorTests` - All 20 tests passed
3. Verify no regression: All existing tests still pass

## Breaking Changes

None - This is a new module with no impact on existing code.