### PR TITLE
docs(project): document and ignore unified_system directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,10 @@ tmp/
 temp/
 *.tmp
 *.temp
+
+# =============================================================================
+# Local Development Directories
+# =============================================================================
+# unified_system/ - Contains separate Git repositories for local development
+# This directory is not part of the OSX Cleaner project
+unified_system/

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -97,6 +97,25 @@ Install these extensions:
 
 Open `Package.swift` directly in Xcode for Swift development.
 
+### 5. Local Development Directories
+
+The project root may contain local development directories that are not part of the OSX Cleaner codebase. These are excluded from version control via `.gitignore`.
+
+#### `unified_system/`
+
+This directory is used for **local development and experimentation** with separate projects. It contains independent Git repositories (e.g., `claude_code_agent`) that are not related to OSX Cleaner.
+
+**Important Notes:**
+- **Not part of OSX Cleaner**: This directory and its contents are completely independent projects
+- **Already ignored**: Listed in `.gitignore` under "Local Development Directories"
+- **Do not commit**: These directories should never be committed to the OSX Cleaner repository
+- **Safe to delete**: You can safely remove this directory if not needed for your local development
+
+**If you see this directory:**
+- It's a local development artifact on someone's machine
+- It's automatically excluded from git tracking
+- You don't need to worry about it for OSX Cleaner development
+
 ---
 
 ## Project Structure


### PR DESCRIPTION
Closes #175

## Summary
- Add `unified_system/` to `.gitignore` to exclude independent local development repositories
- Document the `unified_system/` directory in `CONTRIBUTING.md` to clarify its purpose for contributors
- Explain that this directory contains separate Git repositories for local development and is not part of OSX Cleaner

## Investigation Results

1. **Directory Contents**: The `unified_system/` directory contains a separate Git repository (`claude_code_agent`) with URL `https://github.com/kcenon/claude_code_agent.git`
2. **Codebase References**: No references to `unified_system` found in the main OSX Cleaner codebase
3. **Git History**: No previous commits related to this directory

## Decision: Option 2 - Add to .gitignore

Based on the investigation, I've chosen **Option 2** from the issue (Add to `.gitignore` with documentation) because:
- The directory contains a completely separate project (AD-SDLC) unrelated to OSX Cleaner
- It's a local development artifact that should not be tracked
- Adding it to `.gitignore` prevents accidental commits
- Documentation in `CONTRIBUTING.md` clarifies its purpose for other contributors

## Changes Made

### `.gitignore`
- Added new section "Local Development Directories"
- Added `unified_system/` with explanatory comment

### `docs/CONTRIBUTING.md`
- Added section "5. Local Development Directories" under "Development Setup"
- Documented the purpose and characteristics of `unified_system/`
- Provided clear guidance for contributors encountering this directory

## Test Plan
- [x] Verify `.gitignore` correctly excludes `unified_system/`
- [x] Verify documentation is clear and helpful
- [x] Verify commit message follows conventional commit format
- [x] Verify no AI attribution in commit or PR