### PR TITLE
chore(lint): re-enable SwiftLint todo rule and fix clippy unnecessary_sort_by

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -9,8 +9,7 @@ excluded:
   - rust-core
 
 # Rules configuration
-disabled_rules:
-  - todo  # Allow TODO comments during development
+disabled_rules: []
 
 opt_in_rules:
   - empty_count

--- a/rust-core/src/analyzer/categories.rs
+++ b/rust-core/src/analyzer/categories.rs
@@ -8,6 +8,7 @@
 //! - Application caches analysis
 //! - Developer tools analysis
 
+use std::cmp::Reverse;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -158,7 +159,7 @@ pub fn analyze_home_directory(home_path: &Path, top_n: usize) -> Vec<DirectoryIn
         .collect();
 
     // Sort by size descending
-    dirs.sort_by(|a, b| b.size.cmp(&a.size));
+    dirs.sort_by_key(|dir| Reverse(dir.size));
 
     // Return top N
     dirs.into_iter().take(top_n).collect()
@@ -209,7 +210,7 @@ pub fn analyze_caches(caches_path: &Path) -> Vec<CacheInfo> {
         .collect();
 
     // Sort by size descending
-    caches.sort_by(|a, b| b.size.cmp(&a.size));
+    caches.sort_by_key(|cache| Reverse(cache.size));
     caches
 }
 
@@ -323,7 +324,7 @@ pub fn analyze_developer(developer_path: &Path) -> Vec<DeveloperComponentInfo> {
     }
 
     // Sort by size descending
-    components.sort_by(|a, b| b.size.cmp(&a.size));
+    components.sort_by_key(|comp| Reverse(comp.size));
     components
 }
 

--- a/rust-core/src/analyzer/cleanable.rs
+++ b/rust-core/src/analyzer/cleanable.rs
@@ -5,6 +5,7 @@
 //!
 //! Calculates and categorizes cleanable space by safety level.
 
+use std::cmp::Reverse;
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
@@ -186,7 +187,7 @@ pub fn estimate_cleanable(
     }
 
     // Sort items by size descending
-    items.sort_by(|a, b| b.size.cmp(&a.size));
+    items.sort_by_key(|item| Reverse(item.size));
 
     let total_bytes = safe_bytes + caution_bytes + warning_bytes;
 

--- a/rust-core/src/analyzer/mod.rs
+++ b/rust-core/src/analyzer/mod.rs
@@ -19,6 +19,7 @@ pub use categories::{CacheInfo, CategoryScanner, DeveloperComponentInfo, Directo
 pub use cleanable::{CleanableEstimate, CleanableItem};
 pub use disk_space::DiskSpace;
 
+use std::cmp::Reverse;
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
@@ -183,7 +184,7 @@ impl DiskAnalyzer {
         ];
 
         // Sort by size descending
-        summaries.sort_by(|a, b| b.size.cmp(&a.size));
+        summaries.sort_by_key(|summary| Reverse(summary.size));
         summaries
     }
 }

--- a/rust-core/src/developer/xcode.rs
+++ b/rust-core/src/developer/xcode.rs
@@ -10,6 +10,7 @@
 //! - iOS Device Support (20-100GB): Debug symbols for devices
 //! - watchOS Device Support (5-20GB): Debug symbols for watches
 
+use std::cmp::Reverse;
 use std::collections::HashSet;
 use std::fs;
 use std::path::PathBuf;
@@ -252,7 +253,7 @@ impl XcodeCleaner {
         }
 
         // Sort by version descending (newest first)
-        results.sort_by(|a, b| b.version.cmp(&a.version));
+        results.sort_by_key(|xcode| Reverse(xcode.version.clone()));
 
         results
     }

--- a/rust-core/src/scanner/mod.rs
+++ b/rust-core/src/scanner/mod.rs
@@ -10,6 +10,7 @@
 
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
+use std::cmp::Reverse;
 use std::collections::HashMap;
 use std::path::Path;
 use walkdir::WalkDir;
@@ -166,12 +167,12 @@ pub fn analyze_with_config(path: &str, config: &ScanConfig) -> Result<AnalysisRe
 
     // Get top 10 largest files
     let mut largest = file_infos.clone();
-    largest.sort_by(|a, b| b.size.cmp(&a.size));
+    largest.sort_by_key(|entry| Reverse(entry.size));
     let largest_items: Vec<FileInfo> = largest.into_iter().take(10).collect();
 
     // Get top 10 oldest files
     let mut oldest = file_infos;
-    oldest.sort_by(|a, b| a.modified.cmp(&b.modified));
+    oldest.sort_by_key(|entry| entry.modified);
     let oldest_items: Vec<FileInfo> = oldest.into_iter().take(10).collect();
 
     Ok(AnalysisResult {

--- a/rust-core/src/targets/app_cache.rs
+++ b/rust-core/src/targets/app_cache.rs
@@ -10,6 +10,7 @@
 //! This module scans all application caches and provides
 //! intelligent cleanup options based on size and safety.
 
+use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -370,7 +371,7 @@ impl AppCacheCleaner {
     /// Get top N caches by size
     pub fn get_top_caches(&self, n: usize) -> Vec<AppCacheEntry> {
         let mut caches = self.scan_all_caches();
-        caches.sort_by(|a, b| b.size.cmp(&a.size));
+        caches.sort_by_key(|cache| Reverse(cache.size));
         caches.into_iter().take(n).collect()
     }
 


### PR DESCRIPTION
## What

Two lint hygiene fixes grouped together:

1. **SwiftLint**: Remove `todo` from `.swiftlint.yml` `disabled_rules` so future TODO/FIXME/HACK comments get flagged. Sources/ is currently clean.
2. **Clippy**: Replace nine `sort_by(|a, b| b.X.cmp(&a.X))` patterns with `sort_by_key(|x| Reverse(x.X))` to satisfy Clippy 1.95.0's stricter `unnecessary_sort_by` lint.

## Why

- SwiftLint portion closes #242.
- Clippy portion is an **unblocker** — the newly-shipped `rustc-stable`/`clippy` version flagged existing rust-core code with `-D warnings`, which made every PR fail CI's Rust Check job. Fixing here lets the rest of the F18.x follow-up PRs pass CI.

## How

### SwiftLint (.swiftlint.yml)
- Replace `disabled_rules:\n  - todo` with `disabled_rules: []`.

### Clippy (rust-core/src/)
- `analyzer/categories.rs` (3 sites), `analyzer/cleanable.rs` (1), `analyzer/mod.rs` (1), `scanner/mod.rs` (2), `targets/app_cache.rs` (1), `developer/xcode.rs` (1).
- For descending sorts on `Copy` fields (u64): `sort_by_key(|x| Reverse(x.size))`.
- For ascending sort on `Option<i64>`: `sort_by_key(|x| x.modified)`.
- For descending on `String` (xcode version): `sort_by_key(|x| Reverse(x.version.clone()))`.

## Test Plan

- `cargo clippy -- -D warnings` passes locally.
- `cargo test` — 340 tests pass.
- CI's SwiftLint Security Rules job exercises the re-enabled rule.

Closes #242