### PR TITLE
docs: align README macOS minimum with Package.swift (14.0)

### DIFF
--- a/README.kr.md
+++ b/README.kr.md
@@ -2,7 +2,7 @@
 
 > **macOS 시스템 정리 도구** - 안전하게 불필요한 파일을 정리하여 디스크 공간을 확보합니다.
 
-[![macOS](https://img.shields.io/badge/macOS-10.15--15.x-blue.svg)](https://www.apple.com/macos/)
+[![macOS](https://img.shields.io/badge/macOS-14.0%2B-blue.svg)](https://www.apple.com/macos/)
 [![License](https://img.shields.io/badge/License-BSD--3--Clause-blue.svg)](LICENSE)
 [![Status](https://img.shields.io/badge/Status-Development-orange.svg)]()
 
@@ -18,7 +18,7 @@
 |-----|------|
 | **안전 최우선** | 4단계 안전 등급 시스템으로 시스템 손상 방지 |
 | **개발자 친화적** | Xcode, Docker, npm, Homebrew 등 개발 도구 캐시 전문 관리 (50-150GB 절약 가능) |
-| **버전 호환성** | macOS Catalina(10.15)부터 Sequoia(15.x)까지 완벽 지원 |
+| **버전 호환성** | macOS Sonoma(14.0) 이상 지원 (Sequoia 15.x까지 검증 완료) |
 | **자동화 지원** | launchd 기반 스케줄링 및 CI/CD 파이프라인 통합 |
 
 ---
@@ -479,7 +479,7 @@ osxcleaner clean --level deep --dry-run --format json
 ## 시스템 요구사항
 
 ### 지원 플랫폼
-- **macOS 버전**: 10.15 (Catalina) ~ 15.x (Sequoia)
+- **macOS 버전**: 14.0 (Sonoma) 이상 (15.x Sequoia까지 검증)
 - **아키텍처**: Intel x64, Apple Silicon (arm64)
 
 ### 권장 사양

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **macOS System Cleaning Tool** - Safely clean unnecessary files to free up disk space.
 
-[![macOS](https://img.shields.io/badge/macOS-10.15--15.x-blue.svg)](https://www.apple.com/macos/)
+[![macOS](https://img.shields.io/badge/macOS-14.0%2B-blue.svg)](https://www.apple.com/macos/)
 [![License](https://img.shields.io/badge/License-BSD--3--Clause-blue.svg)](LICENSE)
 [![Status](https://img.shields.io/badge/Status-Development-orange.svg)]()
 [![codecov](https://codecov.io/gh/kcenon/osx_cleaner/branch/main/graph/badge.svg)](https://codecov.io/gh/kcenon/osx_cleaner)
@@ -21,7 +21,7 @@
 |-------|-------------|
 | **Safety First** | 4-level safety classification system prevents system damage |
 | **Developer-Focused** | Specialized management of development tool caches including Xcode, Docker, npm, Homebrew (can save 50-150GB) |
-| **Version Compatibility** | Full support from macOS Catalina (10.15) to Sequoia (15.x) |
+| **Version Compatibility** | Supports macOS Sonoma (14.0) and later, including Sequoia (15.x) |
 | **Automation Support** | launchd-based scheduling and CI/CD pipeline integration |
 
 ---
@@ -482,7 +482,7 @@ The `--format json` flag outputs machine-readable results for CI/CD integration:
 ## System Requirements
 
 ### Supported Platforms
-- **macOS Version**: 10.15 (Catalina) ~ 15.x (Sequoia)
+- **macOS Version**: 14.0 (Sonoma) or later (tested through 15.x Sequoia)
 - **Architecture**: Intel x64, Apple Silicon (arm64)
 
 ### Recommended Specifications


### PR DESCRIPTION
## What

Bring `README.md` and `README.kr.md` in line with the actual minimum macOS requirement declared by `Package.swift` (`.macOS(.v14)`) and `project.yml` (`deploymentTarget.macOS: 14.0`).

## Why

- The README badge and System Requirements advertised `10.15 (Catalina) ~ 15.x (Sequoia)`.
- But `swift build` refuses to compile on anything below macOS 14 because of `platforms: [.macOS(.v14)]`.
- Users following the README would hit an immediate build failure and file confused bug reports.

## How

Updated three places in each README:
1. macOS badge: `10.15--15.x` → `14.0%2B`
2. "Version Compatibility" row in the Value Propositions table
3. System Requirements / 지원 플랫폼 section

Kept the roadmap line referring to `10.15 ~ 15.x` as-is — that describes the F10 feature's internal version-detection coverage, not the app's minimum support.

## Test Plan

- `swift build` already succeeds on macOS 14+ (Package.swift is unchanged).
- No code/behavior changes; docs-only diff.

Closes #236