### PR TITLE
chore(build): align Yams dependency to 6.2.0 across Package.swift and project.yml

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -47,7 +47,7 @@ packages:
     from: "1.5.0"
   Yams:
     url: https://github.com/jpsim/Yams.git
-    from: "5.0.0"
+    from: "6.2.0"
 
 targets:
   OSXCleanerGUI:


### PR DESCRIPTION
## What

Bump the Yams declaration in `project.yml` from `5.0.0` → `6.2.0` so both SPM (`Package.swift`) and XcodeGen (`project.yml`) resolve to the same version.

## Why

- `Package.swift:20`: `.package(url: .../Yams.git, from: "6.2.0")`
- `project.yml:50`: `Yams from: "5.0.0"`
- Developers building via `swift build` vs Xcode got different Yams major versions. Yams 6.x removed deprecated APIs present in 5.x, so this is a potential runtime-behavior split.
- The Swift source already compiles against 6.x via Package.swift, so aligning project.yml upward is the safe direction.

## How

Single-line change to `project.yml`.

Ran `xcodegen generate` locally — project regenerates without errors.

## Test Plan

- `xcodegen generate --spec project.yml` succeeds.
- `swift build` (already verified in CI) uses the same version now via both entry points.
- Deeper SSOT work (making one file canonical and generating the other) is intentionally out of scope; filed as a follow-up.

Closes #235