### PR TITLE
security(auth): replace hand-rolled JWT with swift-crypto HMAC

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "6.2.0")
     ],
     targets: [
@@ -51,6 +52,7 @@ let package = Package(
             dependencies: [
                 "COSXCore",
                 .product(name: "Logging", package: "swift-log"),
+                .product(name: "Crypto", package: "swift-crypto"),
                 .product(name: "Yams", package: "Yams")
             ],
             path: "Sources/OSXCleanerKit",

--- a/Sources/OSXCleanerKit/Server/JWTProvider.swift
+++ b/Sources/OSXCleanerKit/Server/JWTProvider.swift
@@ -2,6 +2,7 @@
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
 
 import Foundation
+import Crypto
 import Logging
 
 // MARK: - JWT Errors
@@ -11,6 +12,7 @@ public enum JWTError: LocalizedError, Equatable {
     case invalidToken
     case tokenExpired
     case invalidSignature
+    case unsupportedAlgorithm(String)
     case missingClaim(String)
     case invalidClaim(String)
     case encodingFailed
@@ -24,6 +26,8 @@ public enum JWTError: LocalizedError, Equatable {
             return "JWT token has expired"
         case .invalidSignature:
             return "JWT signature verification failed"
+        case .unsupportedAlgorithm(let alg):
+            return "Unsupported JWT algorithm: \(alg)"
         case .missingClaim(let claim):
             return "Missing required claim: \(claim)"
         case .invalidClaim(let claim):
@@ -43,6 +47,8 @@ public enum JWTError: LocalizedError, Equatable {
              (.encodingFailed, .encodingFailed),
              (.decodingFailed, .decodingFailed):
             return true
+        case (.unsupportedAlgorithm(let l), .unsupportedAlgorithm(let r)):
+            return l == r
         case (.missingClaim(let l), .missingClaim(let r)),
              (.invalidClaim(let l), .invalidClaim(let r)):
             return l == r
@@ -240,13 +246,22 @@ public struct JWTProviderConfig: Sendable {
 
 // MARK: - JWT Provider
 
-/// Actor responsible for JWT token generation and validation
+/// Actor responsible for JWT token generation and validation.
+///
+/// Signing and verification use Apple's `swift-crypto` (`Crypto.HMAC<SHA256>`),
+/// which performs constant-time authentication-code comparison and receives
+/// CVE tracking through the `apple/swift-crypto` repository.
+///
+/// Only the HS256 algorithm is accepted. Tokens presenting `alg: none` or any
+/// other algorithm are rejected during header parsing to defend against
+/// algorithm-confusion attacks.
 public actor JWTProvider {
 
     // MARK: - Properties
 
     private let configuration: JWTProviderConfig
     private let logger: Logger
+    private let signingKey: SymmetricKey
 
     /// Revoked token IDs (jti)
     private var revokedTokens: Set<String> = []
@@ -254,11 +269,17 @@ public actor JWTProvider {
     /// Maximum revoked tokens to store (for memory management)
     private let maxRevokedTokens: Int = 10000
 
+    /// The only algorithm this provider accepts. Hard-coded so that
+    /// `alg: none` and algorithm-confusion attacks are structurally rejected.
+    private static let supportedAlgorithm = "HS256"
+
     // MARK: - Initialization
 
     public init(configuration: JWTProviderConfig) {
         self.configuration = configuration
         self.logger = Logger(label: "com.osxcleaner.jwt-provider")
+        let keyData = Data(configuration.secret.utf8)
+        self.signingKey = SymmetricKey(data: keyData)
     }
 
     // MARK: - Token Generation
@@ -326,7 +347,6 @@ public actor JWTProvider {
     public func validate(token: String) throws -> JWTClaims {
         let claims = try decode(token: token)
 
-        // Check if token is revoked
         if revokedTokens.contains(claims.jti) {
             logger.warning("Attempted to use revoked token", metadata: [
                 "jti": "\(claims.jti)"
@@ -334,7 +354,6 @@ public actor JWTProvider {
             throw JWTError.invalidToken
         }
 
-        // Check expiration
         if claims.isExpired {
             logger.debug("Token expired", metadata: [
                 "jti": "\(claims.jti)",
@@ -343,7 +362,6 @@ public actor JWTProvider {
             throw JWTError.tokenExpired
         }
 
-        // Check not before
         if let nbf = claims.nbf {
             let now = Int(Date().timeIntervalSince1970)
             if now < nbf {
@@ -351,12 +369,10 @@ public actor JWTProvider {
             }
         }
 
-        // Check issuer
         if claims.iss != configuration.issuer {
             throw JWTError.invalidClaim("iss")
         }
 
-        // Check audience if configured
         if let expectedAudience = configuration.audience {
             if claims.aud != expectedAudience {
                 throw JWTError.invalidClaim("aud")
@@ -370,15 +386,12 @@ public actor JWTProvider {
     public func refresh(token: String, user: User) throws -> TokenPair {
         let claims = try validate(token: token)
 
-        // Ensure it's a refresh token
         guard claims.tokenType == .refresh else {
             throw JWTError.invalidClaim("tokenType")
         }
 
-        // Revoke the old refresh token
         revoke(tokenId: claims.jti)
 
-        // Generate new token pair
         return try generateTokenPair(for: user)
     }
 
@@ -388,9 +401,7 @@ public actor JWTProvider {
     public func revoke(tokenId: String) {
         revokedTokens.insert(tokenId)
 
-        // Memory management: remove oldest if over limit
         if revokedTokens.count > maxRevokedTokens {
-            // In production, would use a proper LRU cache
             revokedTokens.removeFirst()
         }
 
@@ -424,7 +435,7 @@ public actor JWTProvider {
     // MARK: - Private Methods
 
     private func encode(claims: JWTClaims) throws -> String {
-        let header = JWTHeader()
+        let header = JWTHeader(alg: Self.supportedAlgorithm)
 
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .secondsSince1970
@@ -434,35 +445,45 @@ public actor JWTProvider {
             throw JWTError.encodingFailed
         }
 
-        let headerBase64 = base64URLEncode(headerData)
-        let claimsBase64 = base64URLEncode(claimsData)
+        let headerBase64 = Self.base64URLEncode(headerData)
+        let claimsBase64 = Self.base64URLEncode(claimsData)
 
         let signatureInput = "\(headerBase64).\(claimsBase64)"
-        let signature = sign(signatureInput)
+        let signatureBase64 = Self.base64URLEncode(mac(for: signatureInput))
 
-        return "\(signatureInput).\(signature)"
+        return "\(signatureInput).\(signatureBase64)"
     }
 
     private func decode(token: String) throws -> JWTClaims {
-        let parts = token.split(separator: ".").map(String.init)
+        let parts = token.split(separator: ".", omittingEmptySubsequences: false).map(String.init)
         guard parts.count == 3 else {
             throw JWTError.invalidToken
         }
 
         let headerBase64 = parts[0]
         let claimsBase64 = parts[1]
-        let signature = parts[2]
+        let signatureBase64 = parts[2]
 
-        // Verify signature
+        // Reject algorithm-confusion attacks (including alg:none) before
+        // touching the signature or payload.
+        try verifyHeader(base64URL: headerBase64)
+
+        // Constant-time HMAC verification via swift-crypto. The signature and
+        // claims are only considered authentic after this check succeeds.
+        guard let providedSignature = Self.base64URLDecode(signatureBase64) else {
+            throw JWTError.invalidSignature
+        }
         let signatureInput = "\(headerBase64).\(claimsBase64)"
-        let expectedSignature = sign(signatureInput)
-
-        guard signature == expectedSignature else {
+        let signatureData = Data(signatureInput.utf8)
+        guard HMAC<SHA256>.isValidAuthenticationCode(
+            providedSignature,
+            authenticating: signatureData,
+            using: signingKey
+        ) else {
             throw JWTError.invalidSignature
         }
 
-        // Decode claims
-        guard let claimsData = base64URLDecode(claimsBase64) else {
+        guard let claimsData = Self.base64URLDecode(claimsBase64) else {
             throw JWTError.decodingFailed
         }
 
@@ -476,66 +497,44 @@ public actor JWTProvider {
         }
     }
 
-    private func sign(_ input: String) -> String {
-        guard let inputData = input.data(using: .utf8),
-              let keyData = configuration.secret.data(using: .utf8) else {
-            return ""
+    private func verifyHeader(base64URL: String) throws {
+        guard let headerData = Self.base64URLDecode(base64URL) else {
+            throw JWTError.invalidToken
         }
-
-        var hash = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
-
-        // HMAC-SHA256
-        keyData.withUnsafeBytes { keyBytes in
-            inputData.withUnsafeBytes { inputBytes in
-                CCHmac(
-                    CCHmacAlgorithm(kCCHmacAlgSHA256),
-                    keyBytes.baseAddress,
-                    keyData.count,
-                    inputBytes.baseAddress,
-                    inputData.count,
-                    &hash
-                )
-            }
+        let header: JWTHeader
+        do {
+            header = try JSONDecoder().decode(JWTHeader.self, from: headerData)
+        } catch {
+            throw JWTError.invalidToken
         }
-
-        return base64URLEncode(Data(hash))
+        guard header.alg == Self.supportedAlgorithm else {
+            throw JWTError.unsupportedAlgorithm(header.alg)
+        }
     }
 
-    private func base64URLEncode(_ data: Data) -> String {
+    private func mac(for input: String) -> Data {
+        let authCode = HMAC<SHA256>.authenticationCode(
+            for: Data(input.utf8),
+            using: signingKey
+        )
+        return Data(authCode)
+    }
+
+    private static func base64URLEncode(_ data: Data) -> String {
         data.base64EncodedString()
             .replacingOccurrences(of: "+", with: "-")
             .replacingOccurrences(of: "/", with: "_")
             .replacingOccurrences(of: "=", with: "")
     }
 
-    private func base64URLDecode(_ string: String) -> Data? {
+    private static func base64URLDecode(_ string: String) -> Data? {
         var base64 = string
             .replacingOccurrences(of: "-", with: "+")
             .replacingOccurrences(of: "_", with: "/")
 
-        // Add padding if necessary
         let paddingLength = (4 - base64.count % 4) % 4
         base64 += String(repeating: "=", count: paddingLength)
 
         return Data(base64Encoded: base64)
     }
 }
-
-// MARK: - CommonCrypto Bridge
-
-import Darwin
-
-private let CC_SHA256_DIGEST_LENGTH: Int32 = 32
-
-@_silgen_name("CCHmac")
-private func CCHmac(
-    _ algorithm: CCHmacAlgorithm,
-    _ key: UnsafeRawPointer?,
-    _ keyLength: Int,
-    _ data: UnsafeRawPointer?,
-    _ dataLength: Int,
-    _ macOut: UnsafeMutableRawPointer?
-)
-
-private typealias CCHmacAlgorithm = UInt32
-private let kCCHmacAlgSHA256: CCHmacAlgorithm = 2

--- a/Tests/OSXCleanerKitTests/JWTProviderSecurityTests.swift
+++ b/Tests/OSXCleanerKitTests/JWTProviderSecurityTests.swift
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+
+import XCTest
+@testable import OSXCleanerKit
+
+/// Security-focused tests for `JWTProvider` after migration to swift-crypto.
+///
+/// Validates the two properties that the hand-rolled implementation could not
+/// guarantee on its own:
+///   - Algorithm confirmation (`alg: HS256` only, `alg: none` and other
+///     algorithms rejected at header parse time).
+///   - Constant-time signature comparison via `HMAC.isValidAuthenticationCode`.
+final class JWTProviderSecurityTests: XCTestCase {
+
+    private let secret = "test-secret-key-for-jwt-signing-32chars"
+    private let issuer = "test-issuer"
+
+    private func makeProvider(audience: String? = nil) -> JWTProvider {
+        let config = JWTProviderConfig(
+            secret: secret,
+            issuer: issuer,
+            audience: audience,
+            accessTokenDuration: 3600,
+            refreshTokenDuration: 86400
+        )
+        return JWTProvider(configuration: config)
+    }
+
+    private func makeUser(role: Role = .operator) -> User {
+        User(username: "tester", email: "tester@example.com", role: role)
+    }
+
+    // MARK: - Round-trip
+
+    func testSignAndVerify_RoundTripsPayload() async throws {
+        let provider = makeProvider()
+        let user = makeUser(role: .admin)
+
+        let token = try await provider.generateToken(for: user, tokenType: .access)
+        let claims = try await provider.validate(token: token)
+
+        XCTAssertEqual(claims.sub, user.id.uuidString)
+        XCTAssertEqual(claims.username, user.username)
+        XCTAssertEqual(claims.role, .admin)
+        XCTAssertEqual(claims.tokenType, .access)
+        XCTAssertEqual(claims.iss, issuer)
+    }
+
+    // MARK: - Expiration
+
+    func testExpiredToken_Rejected() async throws {
+        let provider = makeProvider()
+        let user = makeUser()
+
+        // Negative expiresIn pushes exp into the past.
+        let token = try await provider.generateToken(
+            for: user,
+            tokenType: .access,
+            expiresIn: -60
+        )
+
+        await XCTAssertThrowsErrorAsync(try await provider.validate(token: token)) { error in
+            XCTAssertEqual(error as? JWTError, .tokenExpired)
+        }
+    }
+
+    // MARK: - Signature tampering
+
+    func testTamperedSignature_Rejected() async throws {
+        let provider = makeProvider()
+        let user = makeUser()
+        let token = try await provider.generateToken(for: user, tokenType: .access)
+
+        let parts = token.split(separator: ".").map(String.init)
+        XCTAssertEqual(parts.count, 3)
+        // Flip the signature to a different (but well-formed base64URL) value.
+        let tampered = "\(parts[0]).\(parts[1]).AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+
+        await XCTAssertThrowsErrorAsync(try await provider.validate(token: tampered)) { error in
+            XCTAssertEqual(error as? JWTError, .invalidSignature)
+        }
+    }
+
+    func testTamperedPayload_Rejected() async throws {
+        let provider = makeProvider()
+        let user = makeUser(role: .viewer)
+        let token = try await provider.generateToken(for: user, tokenType: .access)
+
+        // Swap the claims segment with a forged one carrying escalated role.
+        // The signature no longer matches the new payload, so HMAC verification
+        // must fail regardless of the payload contents.
+        let forgedClaimsJSON = #"{"iss":"test-issuer","sub":"00000000-0000-0000-0000-000000000000","aud":null,"exp":\#(Int(Date().timeIntervalSince1970) + 3600),"iat":\#(Int(Date().timeIntervalSince1970)),"nbf":null,"jti":"forged","role":"admin","username":"attacker","email":null,"tokenType":"access"}"#
+        let forgedClaimsBase64 = base64URLEncode(Data(forgedClaimsJSON.utf8))
+        let parts = token.split(separator: ".").map(String.init)
+        let tampered = "\(parts[0]).\(forgedClaimsBase64).\(parts[2])"
+
+        await XCTAssertThrowsErrorAsync(try await provider.validate(token: tampered)) { error in
+            XCTAssertEqual(error as? JWTError, .invalidSignature)
+        }
+    }
+
+    // MARK: - Algorithm confusion
+
+    func testAlgNone_Rejected() async throws {
+        let provider = makeProvider()
+        // Construct an unsigned token with alg:none — the classic
+        // algorithm-confusion attack.
+        let header = #"{"alg":"none","typ":"JWT"}"#
+        let claims = """
+        {"iss":"\(issuer)","sub":"\(UUID().uuidString)","aud":null,\
+        "exp":\(Int(Date().timeIntervalSince1970) + 3600),\
+        "iat":\(Int(Date().timeIntervalSince1970)),\
+        "nbf":null,"jti":"\(UUID().uuidString)","role":"admin",\
+        "username":"attacker","email":null,"tokenType":"access"}
+        """
+        let token = "\(base64URLEncode(Data(header.utf8))).\(base64URLEncode(Data(claims.utf8)))."
+
+        await XCTAssertThrowsErrorAsync(try await provider.validate(token: token)) { error in
+            guard case .unsupportedAlgorithm(let alg) = error as? JWTError else {
+                XCTFail("Expected .unsupportedAlgorithm, got \(error)")
+                return
+            }
+            XCTAssertEqual(alg, "none")
+        }
+    }
+
+    func testUnsupportedAlgorithm_Rejected() async throws {
+        let provider = makeProvider()
+        // Declared HS384 while the actual signature is still HS256; the header
+        // check must fail before any signature verification is attempted.
+        let header = #"{"alg":"HS384","typ":"JWT"}"#
+        let claims = #"{"iss":"\#(issuer)","sub":"x","aud":null,"exp":9999999999,"iat":0,"nbf":null,"jti":"x","role":"admin","username":"x","email":null,"tokenType":"access"}"#
+        let token = "\(base64URLEncode(Data(header.utf8))).\(base64URLEncode(Data(claims.utf8))).ignored"
+
+        await XCTAssertThrowsErrorAsync(try await provider.validate(token: token)) { error in
+            guard case .unsupportedAlgorithm = error as? JWTError else {
+                XCTFail("Expected .unsupportedAlgorithm, got \(error)")
+                return
+            }
+        }
+    }
+
+    // MARK: - Malformed tokens
+
+    func testMalformedToken_Rejected() async throws {
+        let provider = makeProvider()
+
+        for malformed in ["", "only.two", "a.b.c.d", "not-a-jwt"] {
+            await XCTAssertThrowsErrorAsync(try await provider.validate(token: malformed))
+        }
+    }
+
+    // MARK: - Revocation
+
+    func testRevokedToken_Rejected() async throws {
+        let provider = makeProvider()
+        let user = makeUser()
+        let token = try await provider.generateToken(for: user, tokenType: .refresh)
+
+        let claims = try await provider.validate(token: token)
+        await provider.revoke(tokenId: claims.jti)
+
+        await XCTAssertThrowsErrorAsync(try await provider.validate(token: token)) { error in
+            XCTAssertEqual(error as? JWTError, .invalidToken)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func base64URLEncode(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}
+
+// MARK: - Async throwing assertion helper
+
+private func XCTAssertThrowsErrorAsync<T>(
+    _ expression: @autoclosure () async throws -> T,
+    _ message: @autoclosure () -> String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    _ errorHandler: (_ error: Error) -> Void = { _ in }
+) async {
+    do {
+        _ = try await expression()
+        XCTFail(message().isEmpty ? "Expected error, got success" : message(), file: file, line: line)
+    } catch {
+        errorHandler(error)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -48,6 +48,9 @@ packages:
   Yams:
     url: https://github.com/jpsim/Yams.git
     from: "6.2.0"
+  Crypto:
+    url: https://github.com/apple/swift-crypto.git
+    from: "3.0.0"
 
 targets:
   OSXCleanerGUI:
@@ -152,6 +155,8 @@ targets:
     dependencies:
       - package: Logging
       - package: Yams
+      - package: Crypto
+        product: Crypto
     settings:
       base:
         PRODUCT_NAME: OSXCleanerKit


### PR DESCRIPTION
Closes #237

## What
Replace the hand-rolled HMAC-SHA256 code in `JWTProvider` with Apple's `swift-crypto`
(`Crypto.HMAC<SHA256>`). Public API of `JWTProvider`, `JWTClaims`, `TokenPair`, etc. is
unchanged so existing callers (`AccessController`, `RBACTests`) keep working.

## Why

The prior implementation (`Sources/OSXCleanerKit/Server/JWTProvider.swift`) had three
concrete security gaps that the issue calls out:

| Gap | Prior behavior | New behavior |
|---|---|---|
| Timing-unsafe signature comparison | `signature == expectedSignature` on base64 strings | `HMAC<SHA256>.isValidAuthenticationCode(...)` (constant-time) |
| `alg: none` / algorithm confusion | Header never parsed; rejection only via signature mismatch | Header is decoded and `alg` is required to equal `HS256` before signature work |
| Untracked crypto primitive | `@_silgen_name("CCHmac")` direct symbol binding | `swift-crypto` (`apple/swift-crypto`, Apache-2.0, CVE-tracked) |

## Why swift-crypto instead of swift-jwt-kit

The issue lists `swift-jwt-kit` as Option A. After evaluating it:

- **jwt-kit 5.x requires Swift 6.0+**; this project is pinned to Swift 5.9 in
  `Package.swift` and `project.yml`.
- **jwt-kit 4.x** pulls in `async-http-client`, `swift-nio`, `swift-collections` — heavy
  transitive weight for a desktop cleaner app that only needs HMAC verification.
- **swift-crypto** is Apple's official crypto library, receives CVE tracking through
  `apple/swift-crypto`, and its `HMAC.isValidAuthenticationCode` is specifically
  designed for constant-time MAC verification — which is exactly the primitive the
  audit called out as missing.

Net effect: the issue's three acceptance criteria (alg:none rejected, timing-safe
comparison, no more hand-rolled crypto) are satisfied with a much lighter dependency
footprint and no Swift toolchain upgrade.

## Where

Files touched:
- `Sources/OSXCleanerKit/Server/JWTProvider.swift` — internal sign/verify rewrite; new `verifyHeader` gate.
- `Package.swift` — adds `swift-crypto` dep and wires it into `OSXCleanerKit`.
- `project.yml` — same, for the XcodeGen-generated project.
- `Tests/OSXCleanerKitTests/JWTProviderSecurityTests.swift` — new security-focused tests.

## How (verification)

New tests cover each regression path:
- `testSignAndVerify_RoundTripsPayload` — happy path still works.
- `testExpiredToken_Rejected` — `.tokenExpired`.
- `testTamperedSignature_Rejected` — signature byte flip → `.invalidSignature`.
- `testTamperedPayload_Rejected` — forged payload with role escalation → `.invalidSignature`.
- `testAlgNone_Rejected` — `alg:none` header → `.unsupportedAlgorithm("none")`.
- `testUnsupportedAlgorithm_Rejected` — `alg:HS384` header rejected before signature work.
- `testMalformedToken_Rejected` — empty / wrong part count.
- `testRevokedToken_Rejected` — revocation still enforced.

Existing `RBACTests` continues to exercise the same `JWTProvider` surface so the
migration is verified end-to-end.

## Breaking changes

None for external callers. `JWTError` gains a new case
`unsupportedAlgorithm(String)`; exhaustive switches on `JWTError` will need one more
branch (there are no such switches in the codebase today — only `== ` equality checks).

## Local build note

Local `swift build` could not be verified due to a CommandLineTools / SDK version
mismatch on the dev machine (`swiftlang-6.2.3.3.21` compiler vs `swiftlang-6.2.3.3.2`
SDK). Relying on CI per the project's global policy for toolchain-unavailable cases.