### PR TITLE
feat(ui): surface Rust fallback mode via GUI banner and CLI warning

### DIFF
--- a/Sources/OSXCleanerGUI/OSXCleanerApp.swift
+++ b/Sources/OSXCleanerGUI/OSXCleanerApp.swift
@@ -38,6 +38,15 @@ final class AppState: ObservableObject {
     @Published var isLoading: Bool = false
     @Published var lastError: String?
 
+    /// True when the Rust performance core failed to initialize and the
+    /// app is running the Swift fallback. Drives the compatibility-mode
+    /// banner in `ContentView`.
+    @Published var rustFallbackActive: Bool = false
+
+    /// Human-readable reason for fallback activation. `nil` when the Rust
+    /// core initialized normally.
+    @Published var rustFallbackReason: String?
+
     let cleanerService: CleanerService
     let analyzerService: AnalyzerService
     let diskMonitoringService: DiskMonitoringService
@@ -50,6 +59,13 @@ final class AppState: ObservableObject {
         self.diskMonitoringService = DiskMonitoringService.shared
         self.schedulerService = SchedulerService()
         self.configurationService = ConfigurationService()
+
+        // Eagerly initialize the Rust bridge so that `isFallbackMode` is
+        // known before the first view renders. Failures here are already
+        // swallowed into fallback mode by RustBridge itself.
+        try? RustBridge.shared.initialize()
+        self.rustFallbackActive = RustBridge.shared.isFallbackMode
+        self.rustFallbackReason = RustBridge.shared.fallbackError?.localizedDescription
     }
 
     func getDiskSpace() -> DiskSpaceInfo? {

--- a/Sources/OSXCleanerGUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/OSXCleanerGUI/Resources/en.lproj/Localizable.strings
@@ -198,3 +198,9 @@
 "common.save" = "Save";
 "common.loading" = "Loading...";
 "common.error" = "Error";
+
+// MARK: - Fallback mode banner
+
+"banner.fallback.title" = "Running in compatibility mode";
+"banner.fallback.body" = "The Rust performance core is unavailable. Some operations will be slower.";
+"banner.fallback.reason" = "Rust performance core unavailable: %@";

--- a/Sources/OSXCleanerGUI/Resources/ja.lproj/Localizable.strings
+++ b/Sources/OSXCleanerGUI/Resources/ja.lproj/Localizable.strings
@@ -198,3 +198,9 @@
 "common.save" = "保存";
 "common.loading" = "読み込み中...";
 "common.error" = "エラー";
+
+// MARK: - Fallback mode banner
+
+"banner.fallback.title" = "互換モードで実行中";
+"banner.fallback.body" = "Rust パフォーマンスコアを利用できません。一部の操作が遅くなります。";
+"banner.fallback.reason" = "Rust パフォーマンスコアを利用できません: %@";

--- a/Sources/OSXCleanerGUI/Resources/ko.lproj/Localizable.strings
+++ b/Sources/OSXCleanerGUI/Resources/ko.lproj/Localizable.strings
@@ -198,3 +198,9 @@
 "common.save" = "저장";
 "common.loading" = "로딩 중...";
 "common.error" = "오류";
+
+// MARK: - Fallback mode banner
+
+"banner.fallback.title" = "호환 모드로 실행 중";
+"banner.fallback.body" = "Rust 성능 코어를 사용할 수 없습니다. 일부 작업이 느려집니다.";
+"banner.fallback.reason" = "Rust 성능 코어 사용 불가: %@";

--- a/Sources/OSXCleanerGUI/Views/ContentView.swift
+++ b/Sources/OSXCleanerGUI/Views/ContentView.swift
@@ -8,12 +8,18 @@ struct ContentView: View {
     @EnvironmentObject private var appState: AppState
 
     var body: some View {
-        NavigationSplitView {
-            Sidebar()
-        } detail: {
-            selectedView
+        VStack(spacing: 0) {
+            if appState.rustFallbackActive {
+                FallbackModeBanner(reason: appState.rustFallbackReason)
+                    .transition(.move(edge: .top).combined(with: .opacity))
+            }
+            NavigationSplitView {
+                Sidebar()
+            } detail: {
+                selectedView
+            }
+            .navigationSplitViewStyle(.balanced)
         }
-        .navigationSplitViewStyle(.balanced)
     }
 
     @ViewBuilder
@@ -28,6 +34,50 @@ struct ContentView: View {
         case .settings:
             SettingsView()
         }
+    }
+}
+
+/// Persistent banner shown at the top of the window when the Rust core
+/// failed to initialize and the app is running the Swift fallback.
+///
+/// The banner has no dismiss affordance — fallback state persists until
+/// the app restarts with a working Rust core, and silently hiding the
+/// banner would defeat its purpose (telling the user why performance is
+/// degraded).
+struct FallbackModeBanner: View {
+    let reason: String?
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundColor(.orange)
+                .font(.title3)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(L("banner.fallback.title"))
+                    .font(.headline)
+                if let reason, !reason.isEmpty {
+                    Text(String(format: L("banner.fallback.reason"), reason))
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                } else {
+                    Text(L("banner.fallback.body"))
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.orange.opacity(0.12))
+        .overlay(
+            Rectangle()
+                .fill(Color.orange.opacity(0.4))
+                .frame(height: 1),
+            alignment: .bottom
+        )
+        .accessibilityElement(children: .combine)
     }
 }
 

--- a/Sources/OSXCleanerKit/Bridge/RustBridge.swift
+++ b/Sources/OSXCleanerKit/Bridge/RustBridge.swift
@@ -50,8 +50,20 @@ public final class RustBridge {
     /// Whether the Rust core has been initialized
     private var isInitialized = false
 
-    /// Whether operating in fallback mode (Swift-only)
-    private var isFallbackMode = false
+    /// Whether operating in fallback mode (Swift-only).
+    ///
+    /// Publicly readable so that UI layers (GUI banner, CLI warning) can
+    /// surface the degraded state to the user. Mutated only from inside
+    /// `initQueue.sync` during initialization.
+    public private(set) var isFallbackMode = false
+
+    /// The error that triggered fallback mode, if any.
+    ///
+    /// `nil` while Rust core initialization is pending or succeeded. Set
+    /// alongside `isFallbackMode` when all initialization retries have
+    /// failed. UI layers use the `localizedDescription` to explain to the
+    /// user why the app is running in compatibility mode.
+    public private(set) var fallbackError: Error?
 
     /// Maximum number of initialization retry attempts
     private let maxRetryAttempts = 3
@@ -136,13 +148,21 @@ public final class RustBridge {
     /// - Throws: `RustBridgeError.initializationFailed` if fallback mode setup fails
     private func enterFallbackMode(lastError: Error) throws {
         isFallbackMode = true
+        fallbackError = lastError
 
-        // Log fallback mode activation
         AppLogger.shared.error("Entering fallback mode. Last error: \(lastError)")
 
-        // Note: User notification implementation will be added when
-        // the UserNotification system is available in the codebase
-        // For now, we log the event for monitoring
+        // Print a stderr warning so CLI users see the degraded state even
+        // when they are not tailing logs. GUI builds redirect stderr into
+        // the unified log, so this is effectively log-only there; the GUI
+        // surfaces the state through `isFallbackMode` instead.
+        let warning = """
+        WARNING: osx_cleaner is running in compatibility mode.
+                 Rust performance core unavailable: \(lastError.localizedDescription)
+                 Run 'osxcleaner diagnose' for details.
+
+        """
+        FileHandle.standardError.write(Data(warning.utf8))
 
         // Mark initialization as complete (in fallback mode)
         isInitialized = true


### PR DESCRIPTION
Closes #239

## What
Expose the degraded-mode state that `RustBridge` already tracks internally to
both the CLI (stderr warning) and the GUI (persistent orange banner at the top
of the main window). Replaces the `// User notification...will be added`
deferred-work comment in `RustBridge.swift`.

## Why
`RustBridge.enterFallbackMode` previously logged to `AppLogger` only. Users
experienced slower operations without knowing the Rust core had failed,
leading to incorrect bug reports.

## Where

| File | Change |
|---|---|
| `Sources/OSXCleanerKit/Bridge/RustBridge.swift` | `isFallbackMode` and `fallbackError` as `public private(set)`; stderr warning in `enterFallbackMode`. |
| `Sources/OSXCleanerGUI/OSXCleanerApp.swift` | `AppState` eagerly initializes `RustBridge.shared` and publishes `rustFallbackActive` / `rustFallbackReason`. |
| `Sources/OSXCleanerGUI/Views/ContentView.swift` | New `FallbackModeBanner` rendered conditionally above the `NavigationSplitView`. |
| `Sources/OSXCleanerGUI/Resources/{en,ko,ja}.lproj/Localizable.strings` | `banner.fallback.{title,body,reason}` keys for all three supported locales. |

## How (acceptance criteria)

- [x] GUI displays a persistent banner when `isFallbackMode` is true — new
  `FallbackModeBanner` reads `AppState.rustFallbackActive`.
- [x] CLI prints a stderr warning at startup when fallback is active — the
  warning is emitted once, inside `enterFallbackMode`, so every CLI subcommand
  inherits it through `RustBridge.shared`.
- [ ] Banner has a "Details" button opening diagnostics — **deferred**:
  the GUI has no diagnostics view yet and adding one is out of scope for this
  PR. Instead the banner inlines the localized error description, which
  covers the same need (telling the user what went wrong) without a new view.
  Follow-up can wire a button into `Sources/osxcleaner/Commands/DiagnoseCommand.swift`
  equivalent once a GUI diagnostics surface exists.

## Test Plan

Because reliable fallback activation requires a broken Rust core, this change
relies on review + CI Swift compilation rather than unit tests:

1. CI verifies the new code compiles (Swift Check, Full Build).
2. Manual verification path: temporarily break `osx_core_init` linkage →
   launch GUI → banner appears. `osxcleaner analyze` → stderr prints warning.
3. Existing `FFIErrorRecoveryTests` still pass, exercising the retry path that
   precedes fallback.