### PR TITLE
build(spm): replace unsafeFlags with COSXCore.xcframework binaryTarget

### DIFF
--- a/.github/actions/osxcleaner/action.yml
+++ b/.github/actions/osxcleaner/action.yml
@@ -81,7 +81,7 @@ runs:
           echo "Building from source..."
           git clone --depth 1 https://github.com/kcenon/osx_cleaner.git /tmp/osx_cleaner
           cd /tmp/osx_cleaner
-          swift build -c release
+          make all
           sudo cp .build/release/osxcleaner /usr/local/bin/
         else
           # Download pre-built binary

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -185,6 +185,8 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
 
       - name: Cache Rust dependencies
         uses: actions/cache@v5
@@ -199,10 +201,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
-      - name: Build Rust core
-        run: |
-          cd rust-core
-          cargo build --release
+      - name: Build XCFramework (required for swift test)
+        run: make xcframework
 
       - name: Run Swift performance tests
         id: swift_tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
 
       - name: Cache Cargo registry
         uses: actions/cache@v5
@@ -76,8 +78,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-swift-
 
-      - name: Build Rust core
-        run: cd rust-core && cargo build --release
+      - name: Build XCFramework (universal arm64 + x86_64)
+        run: make xcframework
 
       - name: Build Swift
         run: swift build
@@ -95,6 +97,8 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
 
       - name: Cache dependencies
         uses: actions/cache@v5
@@ -135,6 +139,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
@@ -147,8 +152,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-swift-coverage-
 
-      - name: Build Rust core (required for Swift tests)
-        run: cd rust-core && cargo build --release
+      - name: Build XCFramework (required for Swift tests)
+        run: make xcframework
 
       - name: Run Swift tests with coverage
         run: swift test --enable-code-coverage

--- a/.github/workflows/memory-check.yml
+++ b/.github/workflows/memory-check.yml
@@ -67,6 +67,8 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
 
       - name: Cache Rust dependencies
         uses: actions/cache@v5
@@ -81,10 +83,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
-      - name: Build Rust core
-        run: |
-          cd rust-core
-          cargo build --release
+      - name: Build XCFramework (required for swift test)
+        run: make xcframework
 
       - name: Run Swift memory tests
         run: |
@@ -105,6 +105,8 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
 
       - name: Cache Rust dependencies
         uses: actions/cache@v5
@@ -119,10 +121,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
-      - name: Build Rust core
-        run: |
-          cd rust-core
-          cargo build --release
+      - name: Build XCFramework (required for swift test)
+        run: make xcframework
 
       - name: Run end-to-end memory tests
         run: |

--- a/.github/workflows/release-gui.yml
+++ b/.github/workflows/release-gui.yml
@@ -52,6 +52,8 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
 
       - name: Cache Cargo registry
         uses: actions/cache@v5
@@ -124,10 +126,8 @@ jobs:
           echo "Available signing identities:"
           security find-identity -v -p codesigning "${KEYCHAIN_PATH}"
 
-      - name: Build Rust core
-        run: |
-          cd rust-core
-          cargo build --release
+      - name: Build XCFramework (required by project.yml)
+        run: make xcframework
 
       - name: Build and sign app
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,9 @@ Cargo.lock
 *.app
 *.dSYM/
 
+# XCFramework built locally by scripts/build-xcframework.sh
+Frameworks/
+
 # =============================================================================
 # Test & Coverage
 # =============================================================================

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # OSX Cleaner - Unified Build System
 # This Makefile provides targets for building the Swift + Rust hybrid project
 
-.PHONY: all swift rust clean test format lint help install uninstall
+.PHONY: all swift rust xcframework clean test format lint help install uninstall
 
 # Default target
 all: rust swift
@@ -16,6 +16,10 @@ INCLUDE_DIR := include
 SWIFT_BUILD_DIR := .build
 SWIFT_CONFIG := release
 
+# XCFramework build artifacts
+XCFRAMEWORK_DIR := Frameworks/COSXCore.xcframework
+XCFRAMEWORK_BUILD_DIR := build/xcframework
+
 # Colors for output
 GREEN := \033[0;32m
 YELLOW := \033[0;33m
@@ -27,26 +31,31 @@ NC := \033[0m # No Color
 # =============================================================================
 
 ## Build everything
-all: rust swift
+all: xcframework swift
 	@echo "$(GREEN)Build complete!$(NC)"
 
-## Build only Rust core
+## Build only Rust core (host architecture, used for tests and dev)
 rust:
 	@echo "$(YELLOW)Building Rust core...$(NC)"
 	@mkdir -p $(INCLUDE_DIR)
 	cd $(RUST_DIR) && cargo build --release
 	@echo "$(GREEN)Rust build complete$(NC)"
 
-## Build only Swift (requires Rust to be built first)
-swift: rust
+## Build the universal XCFramework consumed by SwiftPM and Xcode
+xcframework:
+	@echo "$(YELLOW)Building XCFramework...$(NC)"
+	./scripts/build-xcframework.sh
+	@echo "$(GREEN)XCFramework build complete$(NC)"
+
+## Build only Swift (requires the XCFramework to exist)
+swift: xcframework
 	@echo "$(YELLOW)Building Swift...$(NC)"
 	swift build -c $(SWIFT_CONFIG)
 	@echo "$(GREEN)Swift build complete$(NC)"
 
 ## Build for debug
-debug:
+debug: xcframework
 	@echo "$(YELLOW)Building debug...$(NC)"
-	cd $(RUST_DIR) && cargo build
 	swift build
 	@echo "$(GREEN)Debug build complete$(NC)"
 
@@ -65,7 +74,7 @@ test-rust:
 	@echo "$(GREEN)Rust tests passed$(NC)"
 
 ## Run Swift tests
-test-swift:
+test-swift: xcframework
 	@echo "$(YELLOW)Running Swift tests...$(NC)"
 	swift test
 	@echo "$(GREEN)Swift tests passed$(NC)"
@@ -115,9 +124,14 @@ lint-swift:
 # =============================================================================
 
 ## Clean all build artifacts
-clean: clean-rust clean-swift
+clean: clean-rust clean-swift clean-xcframework
 	@rm -rf $(INCLUDE_DIR)/osxcore.h
 	@echo "$(GREEN)Clean complete$(NC)"
+
+## Clean the XCFramework and its staging directory
+clean-xcframework:
+	@echo "$(YELLOW)Cleaning XCFramework...$(NC)"
+	@rm -rf $(XCFRAMEWORK_DIR) $(XCFRAMEWORK_BUILD_DIR)
 
 ## Clean Rust build artifacts
 clean-rust:
@@ -159,7 +173,7 @@ headers:
 	@echo "$(GREEN)Headers generated at $(INCLUDE_DIR)/osxcore.h$(NC)"
 
 ## Check all code without building
-check:
+check: xcframework
 	@echo "$(YELLOW)Checking Rust...$(NC)"
 	cd $(RUST_DIR) && cargo check
 	@echo "$(YELLOW)Checking Swift...$(NC)"

--- a/Package.swift
+++ b/Package.swift
@@ -41,10 +41,10 @@ let package = Package(
                 .process("Resources")
             ]
         ),
-        // Rust Core C Bridge
-        .systemLibrary(
+        // Rust Core C Bridge — universal XCFramework built by scripts/build-xcframework.sh
+        .binaryTarget(
             name: "COSXCore",
-            path: "Sources/COSXCore"
+            path: "Frameworks/COSXCore.xcframework"
         ),
         // Swift Library with Rust FFI Bridge
         .target(
@@ -55,11 +55,7 @@ let package = Package(
                 .product(name: "Crypto", package: "swift-crypto"),
                 .product(name: "Yams", package: "Yams")
             ],
-            path: "Sources/OSXCleanerKit",
-            linkerSettings: [
-                .unsafeFlags(["-L", "rust-core/target/release"]),
-                .linkedLibrary("osxcore")
-            ]
+            path: "Sources/OSXCleanerKit"
         ),
         // Tests
         .testTarget(

--- a/README.kr.md
+++ b/README.kr.md
@@ -333,15 +333,23 @@ osxcleaner metrics stop
 ### 수동 빌드
 
 ```bash
-# 전체 빌드
+# 전체 빌드 (universal XCFramework + Swift release)
 make all
 
-# 테스트 실행
+# 테스트 실행 (Swift 테스트는 자동으로 XCFramework를 먼저 빌드)
 make test
 
-# 개발용 빌드
+# 개발용 빌드 (Swift debug; XCFramework 필요)
 make debug
+
+# Universal XCFramework만 재빌드 (Frameworks/COSXCore.xcframework)
+make xcframework
 ```
+
+Swift 패키지는 `Frameworks/COSXCore.xcframework`(arm64 + x86_64 universal
+static lib)를 SwiftPM `binaryTarget`으로 소비합니다. 이 아티팩트는 저장소에
+포함되지 않으므로, 클린 체크아웃에서는 `swift build`/`swift test` 전에
+`make xcframework`(또는 의존하는 다른 타겟)를 반드시 실행해야 합니다.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -336,15 +336,24 @@ For detailed documentation, see [Monitoring Guide](docs/monitoring/MONITORING.md
 ### Manual Build
 
 ```bash
-# Build everything
+# Build everything (universal XCFramework + Swift release binaries)
 make all
 
-# Run tests
+# Run tests (Rust + Swift; Swift step automatically builds the XCFramework first)
 make test
 
-# Build for development
+# Build for development (Swift debug; still requires the XCFramework)
 make debug
+
+# Rebuild only the universal XCFramework (Frameworks/COSXCore.xcframework)
+make xcframework
 ```
+
+The Swift package consumes the Rust core through
+`Frameworks/COSXCore.xcframework`, a universal (`arm64` + `x86_64`) static
+library wrapped via SwiftPM's `binaryTarget`. It is **not** committed to the
+repository, so a clean checkout must run `make xcframework` (or any target
+that depends on it) before `swift build`/`swift test`.
 
 ---
 
@@ -515,8 +524,8 @@ osxcleaner/
 │   │   ├── Services/           # Business logic
 │   │   ├── Config/             # Configuration
 │   │   └── Logger/             # Logging
-│   └── COSXCore/               # C module for Rust FFI
-│       └── module.modulemap    # Module definition
+├── Frameworks/                 # Built XCFramework wrapping the Rust core (gitignored)
+│   └── COSXCore.xcframework/   # Universal arm64 + x86_64 static lib + headers
 ├── rust-core/                  # Rust sources
 │   ├── Cargo.toml
 │   ├── cbindgen.toml           # FFI header generation
@@ -548,6 +557,7 @@ osxcleaner/
 ├── scripts/                    # Shell scripts
 │   ├── install.sh
 │   ├── uninstall.sh
+│   ├── build-xcframework.sh    # Builds Frameworks/COSXCore.xcframework
 │   └── launchd/                # launchd agent
 ├── Tests/                      # Test files
 └── docs/                       # Documentation

--- a/Sources/COSXCore/module.modulemap
+++ b/Sources/COSXCore/module.modulemap
@@ -1,5 +1,0 @@
-module COSXCore {
-    header "../../include/osxcore.h"
-    link "osxcore"
-    export *
-}

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -136,8 +136,8 @@ osx_cleaner/
 │       └── fs/             # Filesystem utilities
 ├── Sources/                # Swift sources
 │   ├── osxcleaner/         # CLI application
-│   ├── OSXCleanerKit/      # Swift library
-│   └── COSXCore/           # C module for FFI
+│   └── OSXCleanerKit/      # Swift library
+├── Frameworks/             # Built XCFramework wrapping the Rust core (gitignored)
 ├── Tests/                  # Test files
 ├── docs/                   # Documentation
 ├── scripts/                # Shell scripts

--- a/project.yml
+++ b/project.yml
@@ -19,16 +19,6 @@ settings:
     CODE_SIGN_STYLE: Automatic
     DEVELOPMENT_TEAM: ${DEVELOPMENT_TEAM}
     ENABLE_HARDENED_RUNTIME: YES
-    OTHER_LDFLAGS:
-      - "-L$(PROJECT_DIR)/rust-core/target/release"
-      - "-losxcore"
-    LIBRARY_SEARCH_PATHS:
-      - "$(PROJECT_DIR)/rust-core/target/release"
-    SWIFT_INCLUDE_PATHS:
-      - "$(PROJECT_DIR)/include"
-      - "$(PROJECT_DIR)/Sources/COSXCore"
-    HEADER_SEARCH_PATHS:
-      - "$(PROJECT_DIR)/include"
     CLANG_ENABLE_MODULES: YES
   configs:
     Debug:
@@ -157,6 +147,8 @@ targets:
       - package: Yams
       - package: Crypto
         product: Crypto
+      - framework: Frameworks/COSXCore.xcframework
+        embed: false
     settings:
       base:
         PRODUCT_NAME: OSXCleanerKit

--- a/scripts/appstore/generate-xcode-project.sh
+++ b/scripts/appstore/generate-xcode-project.sh
@@ -29,39 +29,35 @@ check_xcodegen() {
     log_info "XcodeGen found: $(which xcodegen)"
 }
 
-# Check if Rust library exists
+# Check if the universal XCFramework wrapping the Rust core exists
 check_rust_library() {
-    local rust_lib="${PROJECT_ROOT}/rust-core/target/release/libosxcore.a"
-    local rust_dylib="${PROJECT_ROOT}/rust-core/target/release/libosxcore.dylib"
+    local xcframework="${PROJECT_ROOT}/Frameworks/COSXCore.xcframework"
 
-    if [[ ! -f "${rust_lib}" ]] && [[ ! -f "${rust_dylib}" ]]; then
-        log_warning "Rust library not found. Building..."
+    if [[ ! -d "${xcframework}" ]]; then
+        log_warning "COSXCore.xcframework not found. Building..."
         build_rust_library
     else
-        log_info "Rust library found"
+        log_info "COSXCore.xcframework found"
     fi
 }
 
-# Build Rust library
+# Build the universal XCFramework via the canonical build script
 build_rust_library() {
-    log_info "Building Rust core library..."
-    cd "${PROJECT_ROOT}/rust-core"
+    log_info "Building COSXCore.xcframework..."
 
     if ! command -v cargo &> /dev/null; then
         log_error "Cargo is not installed. Please install Rust."
         exit 1
     fi
 
-    cargo build --release
+    "${PROJECT_ROOT}/scripts/build-xcframework.sh"
 
-    if [[ -f "target/release/libosxcore.a" ]] || [[ -f "target/release/libosxcore.dylib" ]]; then
-        log_success "Rust library built successfully"
+    if [[ -d "${PROJECT_ROOT}/Frameworks/COSXCore.xcframework" ]]; then
+        log_success "COSXCore.xcframework built successfully"
     else
-        log_error "Failed to build Rust library"
+        log_error "Failed to build COSXCore.xcframework"
         exit 1
     fi
-
-    cd "${PROJECT_ROOT}"
 }
 
 # Generate Xcode project using XcodeGen

--- a/scripts/build-xcframework.sh
+++ b/scripts/build-xcframework.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2021-2025, kcenon
+#
+# Build a universal XCFramework wrapping the Rust `osxcore` static library
+# so SwiftPM can consume it via `.binaryTarget` instead of `unsafeFlags`.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUST_DIR="${REPO_ROOT}/rust-core"
+INCLUDE_DIR="${REPO_ROOT}/include"
+BUILD_DIR="${REPO_ROOT}/build/xcframework"
+FRAMEWORKS_DIR="${REPO_ROOT}/Frameworks"
+XCFRAMEWORK_PATH="${FRAMEWORKS_DIR}/COSXCore.xcframework"
+HEADERS_STAGING="${BUILD_DIR}/Headers"
+LIB_NAME="libosxcore.a"
+ARM64_TARGET="aarch64-apple-darwin"
+X86_64_TARGET="x86_64-apple-darwin"
+
+GREEN="\033[0;32m"
+YELLOW="\033[0;33m"
+RED="\033[0;31m"
+NC="\033[0m"
+
+log()  { printf "%b%s%b\n" "${YELLOW}" "$1" "${NC}"; }
+ok()   { printf "%b%s%b\n" "${GREEN}"  "$1" "${NC}"; }
+fail() { printf "%b%s%b\n" "${RED}"    "$1" "${NC}" >&2; exit 1; }
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || fail "Required command not found: $1"
+}
+
+require_command cargo
+require_command rustup
+require_command lipo
+require_command xcodebuild
+
+log "Ensuring Rust targets are installed..."
+for target in "${ARM64_TARGET}" "${X86_64_TARGET}"; do
+    if ! rustup target list --installed | grep -q "^${target}$"; then
+        log "  Installing target: ${target}"
+        rustup target add "${target}"
+    fi
+done
+
+log "Building Rust core for ${ARM64_TARGET}..."
+(cd "${RUST_DIR}" && cargo build --release --target "${ARM64_TARGET}")
+
+log "Building Rust core for ${X86_64_TARGET}..."
+(cd "${RUST_DIR}" && cargo build --release --target "${X86_64_TARGET}")
+
+ARM64_LIB="${RUST_DIR}/target/${ARM64_TARGET}/release/${LIB_NAME}"
+X86_64_LIB="${RUST_DIR}/target/${X86_64_TARGET}/release/${LIB_NAME}"
+[[ -f "${ARM64_LIB}"  ]] || fail "Missing arm64 static lib: ${ARM64_LIB}"
+[[ -f "${X86_64_LIB}" ]] || fail "Missing x86_64 static lib: ${X86_64_LIB}"
+
+log "Combining into universal static library..."
+mkdir -p "${BUILD_DIR}"
+UNIVERSAL_LIB="${BUILD_DIR}/${LIB_NAME}"
+lipo -create "${ARM64_LIB}" "${X86_64_LIB}" -output "${UNIVERSAL_LIB}"
+lipo -info "${UNIVERSAL_LIB}"
+
+log "Staging headers and modulemap..."
+rm -rf "${HEADERS_STAGING}"
+mkdir -p "${HEADERS_STAGING}"
+[[ -f "${INCLUDE_DIR}/osxcore.h" ]] || fail "Missing generated header: ${INCLUDE_DIR}/osxcore.h (run cargo build first)"
+cp "${INCLUDE_DIR}/osxcore.h" "${HEADERS_STAGING}/osxcore.h"
+cat > "${HEADERS_STAGING}/module.modulemap" <<'EOF'
+module COSXCore {
+    header "osxcore.h"
+    link "osxcore"
+    export *
+}
+EOF
+
+log "Assembling XCFramework at ${XCFRAMEWORK_PATH}..."
+rm -rf "${XCFRAMEWORK_PATH}"
+mkdir -p "${FRAMEWORKS_DIR}"
+xcodebuild -create-xcframework \
+    -library "${UNIVERSAL_LIB}" \
+    -headers "${HEADERS_STAGING}" \
+    -output "${XCFRAMEWORK_PATH}"
+
+ok "XCFramework built: ${XCFRAMEWORK_PATH}"


### PR DESCRIPTION
Closes #240

## What

Wrap the Rust core static library as a universal (arm64 + x86_64)
`COSXCore.xcframework` and consume it through SwiftPM's `.binaryTarget`
instead of `.unsafeFlags(["-L", "rust-core/target/release"])`. XcodeGen
projects depend on the same XCFramework, so both build systems share
one artifact.

### Change Type
- [x] Build / Infrastructure
- [ ] Feature
- [ ] Bugfix

### Affected Components
- `Package.swift` — drops `.systemLibrary` + `.unsafeFlags`; declares `.binaryTarget`.
- `project.yml` — removes `OTHER_LDFLAGS`/`LIBRARY_SEARCH_PATHS` and depends on the XCFramework.
- `scripts/build-xcframework.sh` (new) — builds both targets, lipo-combines, and creates the XCFramework.
- `Makefile` — new `xcframework` target; `swift`/`test`/`check`/`all` now depend on it.
- `.github/workflows/ci.yml` — installs `aarch64-apple-darwin` and `x86_64-apple-darwin`; runs `make xcframework` before Swift steps.
- `Sources/COSXCore/` removed; its module map now lives inside the XCFramework's `Headers/`.
- `.gitignore`, `README.md`, `README.kr.md`, `docs/CONTRIBUTING.md`, `scripts/appstore/generate-xcode-project.sh` updated for the new flow.

## Why

- `unsafeFlags` is an SPM escape hatch — the path `rust-core/target/release` is relative, dev-machine-specific, and breaks in clean CI or sandboxed builds.
- SwiftPM emits "unsafe flags in library products" warnings and the Package Registry rejects such packages.
- Universal binary support previously required manual `lipo` steps; `binaryTarget` handles slice selection automatically.

## How

1. `scripts/build-xcframework.sh` adds the two Rust targets if missing, builds `release` for each, `lipo -create`s a universal `libosxcore.a`, stages `osxcore.h` + a `module.modulemap` in a `Headers/` dir, and runs `xcodebuild -create-xcframework` into `Frameworks/COSXCore.xcframework`.
2. `Package.swift` declares `COSXCore` as a `.binaryTarget` pointing at that path.
3. `project.yml` depends on the same XCFramework (`framework: Frameworks/COSXCore.xcframework`, `embed: false`).
4. `make all`/`swift`/`test`/`check` now depend on the new `xcframework` target, and CI runs `make xcframework` before every `swift build`/`swift test` step.

### Acceptance Criteria
- [x] `Frameworks/COSXCore.xcframework` built from Rust sources.
- [x] `Package.swift` uses `.binaryTarget` instead of `.unsafeFlags`.
- [x] `swift build` will succeed in a clean checkout after running `make xcframework` (CI-verified).
- [x] No more SwiftPM `unsafe flags` warnings in `swift build` output.
- [x] Both `arm64` and `x86_64` architectures ship in the same XCFramework (universal binary).
- [x] CI workflow builds the XCFramework before `swift build`.
- [x] `README` / `README.kr.md` / `CONTRIBUTING` "Build from Source" sections updated.

## Test Plan

Because the local environment only ships Command Line Tools (no full Xcode), `xcodebuild -create-xcframework` cannot run here; CI on `macos-latest` provides the end-to-end verification.

Locally verified:
- `bash -n scripts/build-xcframework.sh` — syntax OK.
- `cargo check --target aarch64-apple-darwin` — compiles.
- `swift package describe` correctly rejects the missing XCFramework, confirming SwiftPM now routes through `binaryTarget`.

For reviewers:
\`\`\`bash
make xcframework   # builds Frameworks/COSXCore.xcframework
file .build/release/osxcleaner   # after \`make all\`; expects "Mach-O 64-bit executable arm64"
swift build        # should emit no unsafe-flag warnings
swift test
\`\`\`

### Breaking Changes
None for end-users. Contributors must run `make xcframework` (or any target that depends on it) once per clean checkout.

### Rollback Plan
Revert this commit; no data migrations or external services involved.