### PR TITLE
feat(rust-core/developer): bound Xcode and simulator external command execution (#267)

### DIFF
--- a/rust-core/src/developer/simulator.rs
+++ b/rust-core/src/developer/simulator.rs
@@ -11,15 +11,25 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
-use std::process::Command;
+use std::sync::Arc;
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
 use super::{
-    calculate_dir_size, expand_home, CleanupError, CleanupMethod, CleanupResult, CleanupTarget,
-    DeveloperCleaner, DeveloperTool, ScanResult,
+    calculate_dir_size, expand_home, format_command, CleanupError, CleanupMethod, CleanupResult,
+    CleanupTarget, CommandRunner, DeveloperCleaner, DeveloperCommandError, DeveloperCommandOutput,
+    DeveloperTool, ScanResult, SystemCommandRunner, COMMAND_CLEANUP_TIMEOUT,
 };
 use crate::safety::SafetyLevel;
+
+/// Timeout for simulator-related scan commands (`xcrun simctl list ...`).
+///
+/// Listing devices/runtimes can take longer than a fast probe because Xcode
+/// inspects the on-disk CoreSimulator state, so we give it more headroom than
+/// `COMMAND_PROBE_TIMEOUT`. The bound still prevents a hung `simctl` from
+/// stalling the scan UI indefinitely.
+const SIMULATOR_SCAN_COMMAND_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// iOS Simulator cleaner
 pub struct SimulatorCleaner {
@@ -27,6 +37,8 @@ pub struct SimulatorCleaner {
     devices_path: PathBuf,
     /// Path to CoreSimulator caches
     caches_path: PathBuf,
+    /// Command runner used for all external command invocations.
+    command_runner: Arc<dyn CommandRunner>,
 }
 
 impl Default for SimulatorCleaner {
@@ -41,17 +53,43 @@ impl SimulatorCleaner {
         Self {
             devices_path: expand_home("~/Library/Developer/CoreSimulator/Devices"),
             caches_path: expand_home("~/Library/Developer/CoreSimulator/Caches"),
+            command_runner: Arc::new(SystemCommandRunner),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_command_runner(command_runner: Arc<dyn CommandRunner>) -> Self {
+        Self {
+            command_runner,
+            ..Self::new()
+        }
+    }
+
+    #[cfg(test)]
+    fn with_paths_and_runner(
+        devices_path: PathBuf,
+        caches_path: PathBuf,
+        command_runner: Arc<dyn CommandRunner>,
+    ) -> Self {
+        Self {
+            devices_path,
+            caches_path,
+            command_runner,
         }
     }
 
     /// List all simulators using xcrun simctl
     pub fn list_devices(&self) -> Result<SimulatorList, SimulatorError> {
-        let output = Command::new("xcrun")
-            .args(["simctl", "list", "devices", "-j"])
-            .output()
-            .map_err(|e| SimulatorError::CommandFailed(e.to_string()))?;
+        let output = self
+            .command_runner
+            .run(
+                "xcrun",
+                &["simctl", "list", "devices", "-j"],
+                SIMULATOR_SCAN_COMMAND_TIMEOUT,
+            )
+            .map_err(SimulatorError::from_developer_command_error)?;
 
-        if !output.status.success() {
+        if !output.status_success {
             return Err(SimulatorError::CommandFailed(
                 String::from_utf8_lossy(&output.stderr).to_string(),
             ));
@@ -90,12 +128,18 @@ impl SimulatorCleaner {
 
     /// List all simulator runtimes
     pub fn list_runtimes(&self) -> Result<Vec<SimulatorRuntime>, SimulatorError> {
-        let output = Command::new("xcrun")
-            .args(["simctl", "runtime", "list", "-j"])
-            .output()
-            .map_err(|e| SimulatorError::CommandFailed(e.to_string()))?;
+        let output = match self.command_runner.run(
+            "xcrun",
+            &["simctl", "runtime", "list", "-j"],
+            SIMULATOR_SCAN_COMMAND_TIMEOUT,
+        ) {
+            Ok(output) => output,
+            // Older Xcode versions lack `simctl runtime list`; treat invocation
+            // failures (missing tool, timeout) as "no runtimes reported".
+            Err(_) => return Ok(Vec::new()),
+        };
 
-        if !output.status.success() {
+        if !output.status_success {
             // Runtime list might not be available on older Xcode versions
             return Ok(Vec::new());
         }
@@ -139,12 +183,16 @@ impl SimulatorCleaner {
             return Ok(unavailable.len());
         }
 
-        let output = Command::new("xcrun")
-            .args(["simctl", "delete", "unavailable"])
-            .output()
-            .map_err(|e| SimulatorError::CommandFailed(e.to_string()))?;
+        let output = self
+            .command_runner
+            .run(
+                "xcrun",
+                &["simctl", "delete", "unavailable"],
+                COMMAND_CLEANUP_TIMEOUT,
+            )
+            .map_err(SimulatorError::from_developer_command_error)?;
 
-        if !output.status.success() {
+        if !output.status_success {
             return Err(SimulatorError::CommandFailed(
                 String::from_utf8_lossy(&output.stderr).to_string(),
             ));
@@ -160,12 +208,16 @@ impl SimulatorCleaner {
             return Ok(());
         }
 
-        let output = Command::new("xcrun")
-            .args(["simctl", "erase", "all"])
-            .output()
-            .map_err(|e| SimulatorError::CommandFailed(e.to_string()))?;
+        let output = self
+            .command_runner
+            .run(
+                "xcrun",
+                &["simctl", "erase", "all"],
+                COMMAND_CLEANUP_TIMEOUT,
+            )
+            .map_err(SimulatorError::from_developer_command_error)?;
 
-        if !output.status.success() {
+        if !output.status_success {
             return Err(SimulatorError::CommandFailed(
                 String::from_utf8_lossy(&output.stderr).to_string(),
             ));
@@ -192,6 +244,37 @@ impl SimulatorCleaner {
         } else {
             Vec::new()
         }
+    }
+
+    fn execute_cleanup_command(
+        &self,
+        target: &CleanupTarget,
+        command: &str,
+    ) -> Result<(), CleanupError> {
+        let output = self
+            .command_runner
+            .run("sh", &["-c", command], COMMAND_CLEANUP_TIMEOUT)
+            .map_err(|error| {
+                cleanup_error_from_command_error(target, command.to_string(), error)
+            })?;
+
+        cleanup_result_from_output(target, output)
+    }
+
+    fn execute_cleanup_with_args(
+        &self,
+        target: &CleanupTarget,
+        command: &str,
+        args: &[String],
+    ) -> Result<(), CleanupError> {
+        let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+        let display_command = format_command(command, &arg_refs);
+        let output = self
+            .command_runner
+            .run(command, &arg_refs, COMMAND_CLEANUP_TIMEOUT)
+            .map_err(|error| cleanup_error_from_command_error(target, display_command, error))?;
+
+        cleanup_result_from_output(target, output)
     }
 }
 
@@ -291,84 +374,56 @@ impl DeveloperCleaner for SimulatorCleaner {
         let mut errors = Vec::new();
 
         for target in targets {
-            match &target.cleanup_method {
+            let result = match &target.cleanup_method {
                 CleanupMethod::DirectDelete => {
                     if let Some(path) = &target.path {
                         if !dry_run {
-                            if let Err(e) = fs::remove_dir_all(path) {
-                                errors.push(CleanupError {
-                                    target: target.name.clone(),
-                                    message: e.to_string(),
-                                });
-                                continue;
-                            }
+                            fs::remove_dir_all(path).map_err(|e| CleanupError {
+                                target: target.name.clone(),
+                                message: e.to_string(),
+                            })
+                        } else {
+                            Ok(())
                         }
-                        freed_bytes += target.size;
-                        items_cleaned += 1;
+                    } else {
+                        Err(CleanupError {
+                            target: target.name.clone(),
+                            message: "No path specified for direct delete".to_string(),
+                        })
                     }
                 }
                 CleanupMethod::Command(cmd) => {
-                    if !dry_run {
-                        let output = Command::new("sh").args(["-c", cmd]).output();
-
-                        match output {
-                            Ok(o) if o.status.success() => {
-                                freed_bytes += target.size;
-                                items_cleaned += 1;
-                            }
-                            Ok(o) => {
-                                errors.push(CleanupError {
-                                    target: target.name.clone(),
-                                    message: String::from_utf8_lossy(&o.stderr).to_string(),
-                                });
-                            }
-                            Err(e) => {
-                                errors.push(CleanupError {
-                                    target: target.name.clone(),
-                                    message: e.to_string(),
-                                });
-                            }
-                        }
+                    if dry_run {
+                        Ok(())
                     } else {
-                        freed_bytes += target.size;
-                        items_cleaned += 1;
+                        self.execute_cleanup_command(target, cmd)
                     }
                 }
                 CleanupMethod::CommandWithArgs(cmd, args) => {
-                    if !dry_run {
-                        let output = Command::new(cmd).args(args).output();
-
-                        match output {
-                            Ok(o) if o.status.success() => {
-                                freed_bytes += target.size;
-                                items_cleaned += 1;
-                            }
-                            Ok(o) => {
-                                errors.push(CleanupError {
-                                    target: target.name.clone(),
-                                    message: String::from_utf8_lossy(&o.stderr).to_string(),
-                                });
-                            }
-                            Err(e) => {
-                                errors.push(CleanupError {
-                                    target: target.name.clone(),
-                                    message: e.to_string(),
-                                });
-                            }
-                        }
+                    if dry_run {
+                        Ok(())
                     } else {
-                        freed_bytes += target.size;
-                        items_cleaned += 1;
+                        self.execute_cleanup_with_args(target, cmd, args)
                     }
                 }
-            }
+            };
 
-            log::info!(
-                "{}Cleaned: {} ({} bytes)",
-                if dry_run { "[DRY RUN] " } else { "" },
-                target.name,
-                target.size
-            );
+            match result {
+                Ok(()) => {
+                    freed_bytes += target.size;
+                    items_cleaned += 1;
+                    log::info!(
+                        "{}Cleaned: {} ({} bytes)",
+                        if dry_run { "[DRY RUN] " } else { "" },
+                        target.name,
+                        target.size
+                    );
+                }
+                Err(e) => {
+                    log::warn!("Failed to clean {}: {}", target.name, e.message);
+                    errors.push(e);
+                }
+            }
         }
 
         CleanupResult {
@@ -417,6 +472,52 @@ pub enum SimulatorError {
 
     #[error("Failed to parse output: {0}")]
     ParseError(String),
+
+    #[error("Command timed out: {0}")]
+    CommandTimedOut(String),
+}
+
+impl SimulatorError {
+    fn from_developer_command_error(error: DeveloperCommandError) -> Self {
+        match error {
+            DeveloperCommandError::Io(error) => Self::CommandFailed(error.to_string()),
+            DeveloperCommandError::TimedOut { command, timeout } => {
+                Self::CommandTimedOut(format!("`{}` timed out after {:?}", command, timeout))
+            }
+        }
+    }
+}
+
+fn cleanup_result_from_output(
+    target: &CleanupTarget,
+    output: DeveloperCommandOutput,
+) -> Result<(), CleanupError> {
+    if output.status_success {
+        Ok(())
+    } else {
+        Err(CleanupError {
+            target: target.name.clone(),
+            message: String::from_utf8_lossy(&output.stderr).to_string(),
+        })
+    }
+}
+
+fn cleanup_error_from_command_error(
+    target: &CleanupTarget,
+    command: String,
+    error: DeveloperCommandError,
+) -> CleanupError {
+    let message = match error {
+        DeveloperCommandError::Io(error) => error.to_string(),
+        DeveloperCommandError::TimedOut { timeout, .. } => {
+            format!("`{}` timed out after {:?}", command, timeout)
+        }
+    };
+
+    CleanupError {
+        target: target.name.clone(),
+        message,
+    }
 }
 
 // JSON parsing structures for xcrun simctl output
@@ -453,7 +554,94 @@ struct SimctlRuntime {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::VecDeque;
+    use std::io;
+    use std::sync::Mutex;
     use tempfile::tempdir;
+
+    type MockCommandResult = Result<DeveloperCommandOutput, DeveloperCommandError>;
+
+    #[derive(Default)]
+    struct MockCommandRunner {
+        responses: Mutex<VecDeque<MockCommandResult>>,
+        calls: Mutex<Vec<(String, Vec<String>, Duration)>>,
+    }
+
+    impl MockCommandRunner {
+        fn new(responses: Vec<MockCommandResult>) -> Arc<Self> {
+            Arc::new(Self {
+                responses: Mutex::new(responses.into()),
+                calls: Mutex::new(Vec::new()),
+            })
+        }
+
+        fn success(stdout: impl Into<Vec<u8>>) -> MockCommandResult {
+            Ok(DeveloperCommandOutput {
+                status_success: true,
+                stdout: stdout.into(),
+                stderr: Vec::new(),
+            })
+        }
+
+        fn failure(stderr: impl Into<Vec<u8>>) -> MockCommandResult {
+            Ok(DeveloperCommandOutput {
+                status_success: false,
+                stdout: Vec::new(),
+                stderr: stderr.into(),
+            })
+        }
+
+        fn timeout(command: &str, timeout: Duration) -> MockCommandResult {
+            Err(DeveloperCommandError::TimedOut {
+                command: command.to_string(),
+                timeout,
+            })
+        }
+
+        fn calls(&self) -> Vec<(String, Vec<String>, Duration)> {
+            self.calls
+                .lock()
+                .expect("mock calls lock should not be poisoned")
+                .clone()
+        }
+    }
+
+    impl CommandRunner for MockCommandRunner {
+        fn run(
+            &self,
+            program: &str,
+            args: &[&str],
+            timeout: Duration,
+        ) -> Result<DeveloperCommandOutput, DeveloperCommandError> {
+            self.calls
+                .lock()
+                .expect("mock calls lock should not be poisoned")
+                .push((
+                    program.to_string(),
+                    args.iter().map(|arg| arg.to_string()).collect(),
+                    timeout,
+                ));
+
+            self.responses
+                .lock()
+                .expect("mock responses lock should not be poisoned")
+                .pop_front()
+                .unwrap_or_else(|| {
+                    Err(DeveloperCommandError::Io(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "no mock response configured",
+                    )))
+                })
+        }
+    }
+
+    fn cleaner_with_runner(runner: Arc<dyn CommandRunner>) -> SimulatorCleaner {
+        SimulatorCleaner::with_paths_and_runner(
+            PathBuf::from("/nonexistent"),
+            PathBuf::from("/nonexistent"),
+            runner,
+        )
+    }
 
     #[test]
     fn test_simulator_cleaner_creation() {
@@ -650,10 +838,11 @@ mod tests {
         fs::write(caches_path.join("cache_file.dat"), "test cache data")
             .expect("Failed to write cache file");
 
-        let cleaner = SimulatorCleaner {
-            devices_path: PathBuf::from("/nonexistent"),
+        let cleaner = SimulatorCleaner::with_paths_and_runner(
+            PathBuf::from("/nonexistent"),
             caches_path,
-        };
+            MockCommandRunner::new(Vec::new()),
+        );
 
         let targets = cleaner.scan_caches();
         assert!(!targets.is_empty());
@@ -668,10 +857,11 @@ mod tests {
         fs::create_dir(&caches_path).expect("Failed to create Caches directory");
         // Empty directory - no files
 
-        let cleaner = SimulatorCleaner {
-            devices_path: PathBuf::from("/nonexistent"),
+        let cleaner = SimulatorCleaner::with_paths_and_runner(
+            PathBuf::from("/nonexistent"),
             caches_path,
-        };
+            MockCommandRunner::new(Vec::new()),
+        );
 
         let targets = cleaner.scan_caches();
         // Empty directory should not produce targets (size = 0)
@@ -680,10 +870,11 @@ mod tests {
 
     #[test]
     fn test_scan_caches_nonexistent() {
-        let cleaner = SimulatorCleaner {
-            devices_path: PathBuf::from("/nonexistent"),
-            caches_path: PathBuf::from("/nonexistent/caches"),
-        };
+        let cleaner = SimulatorCleaner::with_paths_and_runner(
+            PathBuf::from("/nonexistent"),
+            PathBuf::from("/nonexistent/caches"),
+            MockCommandRunner::new(Vec::new()),
+        );
 
         let targets = cleaner.scan_caches();
         assert!(targets.is_empty());
@@ -696,6 +887,9 @@ mod tests {
 
         let parse_error = SimulatorError::ParseError("invalid JSON".to_string());
         assert!(parse_error.to_string().contains("parse output"));
+
+        let timeout_error = SimulatorError::CommandTimedOut("xcrun simctl list".to_string());
+        assert!(timeout_error.to_string().contains("Command timed out"));
     }
 
     #[test]
@@ -761,14 +955,288 @@ mod tests {
     #[test]
     fn test_get_unavailable_simulators_graceful_failure() {
         // When xcrun is not available or fails, should return empty vec
-        let cleaner = SimulatorCleaner {
-            devices_path: PathBuf::from("/nonexistent"),
-            caches_path: PathBuf::from("/nonexistent"),
+        let runner = MockCommandRunner::new(vec![MockCommandRunner::failure("xcrun not found")]);
+        let cleaner = cleaner_with_runner(runner);
+
+        let unavailable = cleaner.get_unavailable_simulators();
+        assert!(unavailable.is_empty());
+    }
+
+    #[test]
+    fn test_list_devices_uses_scan_timeout() {
+        let runner = MockCommandRunner::new(vec![MockCommandRunner::success(
+            r#"{"devices": {}}"#,
+        )]);
+        let cleaner = cleaner_with_runner(runner.clone());
+
+        let list = cleaner
+            .list_devices()
+            .expect("mocked simctl list should succeed");
+        assert!(list.devices.is_empty());
+
+        let calls = runner.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "xcrun");
+        assert_eq!(calls[0].1, vec!["simctl", "list", "devices", "-j"]);
+        assert_eq!(calls[0].2, SIMULATOR_SCAN_COMMAND_TIMEOUT);
+    }
+
+    #[test]
+    fn test_list_devices_timeout_surfaces_structured_error() {
+        let runner = MockCommandRunner::new(vec![MockCommandRunner::timeout(
+            "xcrun simctl list devices -j",
+            SIMULATOR_SCAN_COMMAND_TIMEOUT,
+        )]);
+        let cleaner = cleaner_with_runner(runner);
+
+        let error = cleaner
+            .list_devices()
+            .expect_err("timeout should surface as simulator error");
+
+        assert!(matches!(error, SimulatorError::CommandTimedOut(_)));
+    }
+
+    #[test]
+    fn test_list_runtimes_uses_scan_timeout() {
+        let runner = MockCommandRunner::new(vec![MockCommandRunner::success(
+            r#"{"runtimes": []}"#,
+        )]);
+        let cleaner = cleaner_with_runner(runner.clone());
+
+        let runtimes = cleaner
+            .list_runtimes()
+            .expect("mocked simctl runtime list should succeed");
+        assert!(runtimes.is_empty());
+
+        let calls = runner.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "xcrun");
+        assert_eq!(calls[0].1, vec!["simctl", "runtime", "list", "-j"]);
+        assert_eq!(calls[0].2, SIMULATOR_SCAN_COMMAND_TIMEOUT);
+    }
+
+    #[test]
+    fn test_list_runtimes_timeout_returns_empty_vec() {
+        // `simctl runtime list` is best-effort; a timeout/missing tool should
+        // be reported as "no runtimes" rather than failing the entire scan.
+        let runner = MockCommandRunner::new(vec![MockCommandRunner::timeout(
+            "xcrun simctl runtime list -j",
+            SIMULATOR_SCAN_COMMAND_TIMEOUT,
+        )]);
+        let cleaner = cleaner_with_runner(runner);
+
+        let runtimes = cleaner
+            .list_runtimes()
+            .expect("timeout should be silently degraded to empty list");
+        assert!(runtimes.is_empty());
+    }
+
+    #[test]
+    fn test_get_unavailable_simulators_parses_runner_output() {
+        let json = r#"{
+            "devices": {
+                "iOS-17-0": [
+                    {"name":"iPhone 15","udid":"u1","state":"Shutdown","isAvailable":true},
+                    {"name":"iPhone 14","udid":"u2","state":"Shutdown","isAvailable":false}
+                ]
+            }
+        }"#;
+        let runner = MockCommandRunner::new(vec![MockCommandRunner::success(json)]);
+        let cleaner = cleaner_with_runner(runner);
+
+        let unavailable = cleaner.get_unavailable_simulators();
+        assert_eq!(unavailable.len(), 1);
+        assert_eq!(unavailable[0].name, "iPhone 14");
+    }
+
+    #[test]
+    fn test_delete_unavailable_dry_run_does_not_execute_command() {
+        // Dry run should only invoke the list (probe) command, never the delete.
+        let runner = MockCommandRunner::new(vec![MockCommandRunner::success(
+            r#"{"devices": {}}"#,
+        )]);
+        let cleaner = cleaner_with_runner(runner.clone());
+
+        let count = cleaner
+            .delete_unavailable(true)
+            .expect("dry run should not fail");
+        assert_eq!(count, 0);
+
+        let calls = runner.calls();
+        assert_eq!(calls.len(), 1);
+        // Only the list_devices probe should have been called.
+        assert_eq!(calls[0].1, vec!["simctl", "list", "devices", "-j"]);
+    }
+
+    #[test]
+    fn test_delete_unavailable_runs_command_when_not_dry_run() {
+        let runner = MockCommandRunner::new(vec![MockCommandRunner::success("")]);
+        let cleaner = cleaner_with_runner(runner.clone());
+
+        cleaner
+            .delete_unavailable(false)
+            .expect("mock delete should succeed");
+
+        let calls = runner.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "xcrun");
+        assert_eq!(calls[0].1, vec!["simctl", "delete", "unavailable"]);
+        assert_eq!(calls[0].2, COMMAND_CLEANUP_TIMEOUT);
+    }
+
+    #[test]
+    fn test_delete_unavailable_timeout_surfaces_structured_error() {
+        let runner = MockCommandRunner::new(vec![MockCommandRunner::timeout(
+            "xcrun simctl delete unavailable",
+            COMMAND_CLEANUP_TIMEOUT,
+        )]);
+        let cleaner = cleaner_with_runner(runner);
+
+        let error = cleaner
+            .delete_unavailable(false)
+            .expect_err("timeout should surface");
+        assert!(matches!(error, SimulatorError::CommandTimedOut(_)));
+    }
+
+    #[test]
+    fn test_erase_all_dry_run_does_not_execute_command() {
+        let runner = MockCommandRunner::new(Vec::new());
+        let cleaner = cleaner_with_runner(runner.clone());
+
+        cleaner.erase_all(true).expect("dry run should not fail");
+        assert!(runner.calls().is_empty());
+    }
+
+    #[test]
+    fn test_erase_all_runs_command_when_not_dry_run() {
+        let runner = MockCommandRunner::new(vec![MockCommandRunner::success("")]);
+        let cleaner = cleaner_with_runner(runner.clone());
+
+        cleaner.erase_all(false).expect("mock erase should succeed");
+
+        let calls = runner.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "xcrun");
+        assert_eq!(calls[0].1, vec!["simctl", "erase", "all"]);
+        assert_eq!(calls[0].2, COMMAND_CLEANUP_TIMEOUT);
+    }
+
+    #[test]
+    fn test_erase_all_timeout_surfaces_structured_error() {
+        let runner = MockCommandRunner::new(vec![MockCommandRunner::timeout(
+            "xcrun simctl erase all",
+            COMMAND_CLEANUP_TIMEOUT,
+        )]);
+        let cleaner = cleaner_with_runner(runner);
+
+        let error = cleaner.erase_all(false).expect_err("timeout should surface");
+        assert!(matches!(error, SimulatorError::CommandTimedOut(_)));
+    }
+
+    #[test]
+    fn test_clean_dry_run_does_not_execute_command() {
+        let runner = MockCommandRunner::new(Vec::new());
+        let cleaner = cleaner_with_runner(runner.clone());
+        let target = CleanupTarget::new_command(
+            "Unavailable Simulator: iPhone (abc)",
+            "xcrun simctl delete abc",
+            SafetyLevel::Safe,
+        )
+        .with_size(2048);
+
+        let result = cleaner.clean(&[target], true);
+
+        assert!(result.dry_run);
+        assert_eq!(result.freed_bytes, 2048);
+        assert_eq!(result.items_cleaned, 1);
+        assert!(result.errors.is_empty());
+        assert!(runner.calls().is_empty());
+    }
+
+    #[test]
+    fn test_clean_command_timeout_records_structured_error() {
+        let runner = MockCommandRunner::new(vec![MockCommandRunner::timeout(
+            "xcrun simctl delete abc",
+            COMMAND_CLEANUP_TIMEOUT,
+        )]);
+        let cleaner = cleaner_with_runner(runner.clone());
+        let target = CleanupTarget::new_command(
+            "Unavailable Simulator: iPhone (abc)",
+            "xcrun simctl delete abc",
+            SafetyLevel::Safe,
+        )
+        .with_size(2048);
+
+        let result = cleaner.clean(&[target], false);
+
+        assert!(!result.dry_run);
+        assert_eq!(result.freed_bytes, 0);
+        assert_eq!(result.items_cleaned, 0);
+        assert_eq!(result.errors.len(), 1);
+        assert!(result.errors[0].message.contains("timed out"));
+
+        let calls = runner.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "sh");
+        assert_eq!(calls[0].1, vec!["-c", "xcrun simctl delete abc"]);
+        assert_eq!(calls[0].2, COMMAND_CLEANUP_TIMEOUT);
+    }
+
+    #[test]
+    fn test_clean_command_with_args_timeout_records_structured_error() {
+        let runner = MockCommandRunner::new(vec![MockCommandRunner::timeout(
+            "xcrun simctl delete abc",
+            COMMAND_CLEANUP_TIMEOUT,
+        )]);
+        let cleaner = cleaner_with_runner(runner.clone());
+        let target = CleanupTarget {
+            path: None,
+            name: "xcrun delete".to_string(),
+            size: 1024,
+            safety_level: SafetyLevel::Safe,
+            cleanup_method: CleanupMethod::CommandWithArgs(
+                "xcrun".to_string(),
+                vec!["simctl".to_string(), "delete".to_string(), "abc".to_string()],
+            ),
+            description: None,
         };
 
-        // This should not panic even if xcrun fails
+        let result = cleaner.clean(&[target], false);
+
+        assert!(!result.dry_run);
+        assert_eq!(result.errors.len(), 1);
+        assert!(result.errors[0].message.contains("timed out"));
+
+        let calls = runner.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "xcrun");
+        assert_eq!(calls[0].1, vec!["simctl", "delete", "abc"]);
+        assert_eq!(calls[0].2, COMMAND_CLEANUP_TIMEOUT);
+    }
+
+    #[test]
+    fn test_scan_returns_empty_when_simctl_times_out() {
+        // `is_installed` -> list_devices -> list_runtimes all driven via runner.
+        // We mock: is_installed (which/xcrun) probes are handled by real system;
+        // here we just verify that even if list_devices times out the scan does
+        // not panic and surfaces a structured error in `errors`.
+        let runner = MockCommandRunner::new(vec![
+            MockCommandRunner::timeout("xcrun simctl list devices -j", SIMULATOR_SCAN_COMMAND_TIMEOUT),
+            MockCommandRunner::timeout("xcrun simctl runtime list -j", SIMULATOR_SCAN_COMMAND_TIMEOUT),
+        ]);
+        let cleaner = cleaner_with_runner(runner);
+
+        // is_installed() uses the real SystemCommandRunner via DeveloperTool::Simulator
+        // so we cannot fully sandbox it; just exercise scan_caches + helpers directly.
+        let caches = cleaner.scan_caches();
+        assert!(caches.is_empty());
+
         let unavailable = cleaner.get_unavailable_simulators();
-        // Just verify it returns a vector (may be empty or have content depending on system)
-        assert!(unavailable.len() < 1000); // Reasonable upper bound
+        assert!(unavailable.is_empty());
+
+        let runtimes = cleaner
+            .list_runtimes()
+            .expect("runtime list timeout should degrade silently");
+        assert!(runtimes.is_empty());
     }
 }

--- a/rust-core/src/developer/simulator.rs
+++ b/rust-core/src/developer/simulator.rs
@@ -964,9 +964,7 @@ mod tests {
 
     #[test]
     fn test_list_devices_uses_scan_timeout() {
-        let runner = MockCommandRunner::new(vec![MockCommandRunner::success(
-            r#"{"devices": {}}"#,
-        )]);
+        let runner = MockCommandRunner::new(vec![MockCommandRunner::success(r#"{"devices": {}}"#)]);
         let cleaner = cleaner_with_runner(runner.clone());
 
         let list = cleaner
@@ -998,9 +996,8 @@ mod tests {
 
     #[test]
     fn test_list_runtimes_uses_scan_timeout() {
-        let runner = MockCommandRunner::new(vec![MockCommandRunner::success(
-            r#"{"runtimes": []}"#,
-        )]);
+        let runner =
+            MockCommandRunner::new(vec![MockCommandRunner::success(r#"{"runtimes": []}"#)]);
         let cleaner = cleaner_with_runner(runner.clone());
 
         let runtimes = cleaner
@@ -1052,9 +1049,7 @@ mod tests {
     #[test]
     fn test_delete_unavailable_dry_run_does_not_execute_command() {
         // Dry run should only invoke the list (probe) command, never the delete.
-        let runner = MockCommandRunner::new(vec![MockCommandRunner::success(
-            r#"{"devices": {}}"#,
-        )]);
+        let runner = MockCommandRunner::new(vec![MockCommandRunner::success(r#"{"devices": {}}"#)]);
         let cleaner = cleaner_with_runner(runner.clone());
 
         let count = cleaner
@@ -1129,7 +1124,9 @@ mod tests {
         )]);
         let cleaner = cleaner_with_runner(runner);
 
-        let error = cleaner.erase_all(false).expect_err("timeout should surface");
+        let error = cleaner
+            .erase_all(false)
+            .expect_err("timeout should surface");
         assert!(matches!(error, SimulatorError::CommandTimedOut(_)));
     }
 
@@ -1196,7 +1193,11 @@ mod tests {
             safety_level: SafetyLevel::Safe,
             cleanup_method: CleanupMethod::CommandWithArgs(
                 "xcrun".to_string(),
-                vec!["simctl".to_string(), "delete".to_string(), "abc".to_string()],
+                vec![
+                    "simctl".to_string(),
+                    "delete".to_string(),
+                    "abc".to_string(),
+                ],
             ),
             description: None,
         };
@@ -1221,8 +1222,14 @@ mod tests {
         // here we just verify that even if list_devices times out the scan does
         // not panic and surfaces a structured error in `errors`.
         let runner = MockCommandRunner::new(vec![
-            MockCommandRunner::timeout("xcrun simctl list devices -j", SIMULATOR_SCAN_COMMAND_TIMEOUT),
-            MockCommandRunner::timeout("xcrun simctl runtime list -j", SIMULATOR_SCAN_COMMAND_TIMEOUT),
+            MockCommandRunner::timeout(
+                "xcrun simctl list devices -j",
+                SIMULATOR_SCAN_COMMAND_TIMEOUT,
+            ),
+            MockCommandRunner::timeout(
+                "xcrun simctl runtime list -j",
+                SIMULATOR_SCAN_COMMAND_TIMEOUT,
+            ),
         ]);
         let cleaner = cleaner_with_runner(runner);
 

--- a/rust-core/src/developer/xcode.rs
+++ b/rust-core/src/developer/xcode.rs
@@ -14,15 +14,24 @@ use std::cmp::Reverse;
 use std::collections::HashSet;
 use std::fs;
 use std::path::PathBuf;
-use std::process::Command;
+use std::sync::Arc;
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
 use super::{
-    calculate_dir_size, expand_home, CleanupError, CleanupMethod, CleanupResult, CleanupTarget,
-    DeveloperCleaner, DeveloperTool, ScanResult,
+    calculate_dir_size, expand_home, format_command, CleanupError, CleanupMethod, CleanupResult,
+    CleanupTarget, CommandRunner, DeveloperCleaner, DeveloperCommandError, DeveloperCommandOutput,
+    DeveloperTool, ScanResult, SystemCommandRunner, COMMAND_CLEANUP_TIMEOUT, COMMAND_PROBE_TIMEOUT,
 };
 use crate::safety::SafetyLevel;
+
+/// Timeout for Xcode-related scan commands (e.g. `xcrun devicectl list`).
+///
+/// Scan commands may need to enumerate connected devices, so they are given
+/// more headroom than a fast probe but are still kept short to avoid blocking
+/// the UI on a stuck tool.
+const XCODE_SCAN_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Xcode cache cleaner
 pub struct XcodeCleaner {
@@ -34,6 +43,8 @@ pub struct XcodeCleaner {
     ios_device_support_path: PathBuf,
     /// Path to watchOS Device Support
     watchos_device_support_path: PathBuf,
+    /// Command runner used for all external command invocations.
+    command_runner: Arc<dyn CommandRunner>,
 }
 
 impl Default for XcodeCleaner {
@@ -52,16 +63,42 @@ impl XcodeCleaner {
             watchos_device_support_path: expand_home(
                 "~/Library/Developer/Xcode/watchOS DeviceSupport",
             ),
+            command_runner: Arc::new(SystemCommandRunner),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_command_runner(command_runner: Arc<dyn CommandRunner>) -> Self {
+        Self {
+            command_runner,
+            ..Self::new()
+        }
+    }
+
+    #[cfg(test)]
+    fn with_paths_and_runner(
+        derived_data_path: PathBuf,
+        archives_path: PathBuf,
+        ios_device_support_path: PathBuf,
+        watchos_device_support_path: PathBuf,
+        command_runner: Arc<dyn CommandRunner>,
+    ) -> Self {
+        Self {
+            derived_data_path,
+            archives_path,
+            ios_device_support_path,
+            watchos_device_support_path,
+            command_runner,
         }
     }
 
     /// Check if Xcode is currently building
     pub fn is_build_running(&self) -> bool {
-        // Check for running xcodebuild processes
-        Command::new("pgrep")
-            .args(["-x", "xcodebuild"])
-            .output()
-            .map(|o| o.status.success())
+        // Check for running xcodebuild processes through the bounded runner so
+        // a stuck `pgrep` cannot hang a scan.
+        self.command_runner
+            .run("pgrep", &["-x", "xcodebuild"], COMMAND_PROBE_TIMEOUT)
+            .map(|o| o.status_success)
             .unwrap_or(false)
     }
 
@@ -184,19 +221,22 @@ impl XcodeCleaner {
     fn get_connected_versions(&self, target_platform: &str) -> HashSet<String> {
         let mut versions = HashSet::new();
 
-        // Try xcrun devicectl (Xcode 15+)
-        let output = Command::new("xcrun")
-            .args([
+        // Try xcrun devicectl (Xcode 15+) via the bounded runner. A hung or
+        // missing devicectl must not stall a scan.
+        let output = self.command_runner.run(
+            "xcrun",
+            &[
                 "devicectl",
                 "list",
                 "devices",
                 "--json-output",
                 "/dev/stdout",
-            ])
-            .output();
+            ],
+            XCODE_SCAN_COMMAND_TIMEOUT,
+        );
 
         if let Ok(output) = output {
-            if output.status.success() {
+            if output.status_success {
                 let stdout = String::from_utf8_lossy(&output.stdout);
                 if let Ok(parsed) = serde_json::from_str::<DeviceCtlOutput>(&stdout) {
                     for device in parsed.result.devices {
@@ -396,42 +436,32 @@ impl XcodeCleaner {
                 }
             }
             CleanupMethod::Command(cmd) => {
-                if !dry_run {
-                    let output = Command::new("sh").args(["-c", cmd]).output().map_err(|e| {
-                        CleanupError {
-                            target: target.name.clone(),
-                            message: e.to_string(),
-                        }
-                    })?;
-
-                    if !output.status.success() {
-                        return Err(CleanupError {
-                            target: target.name.clone(),
-                            message: String::from_utf8_lossy(&output.stderr).to_string(),
-                        });
-                    }
+                if dry_run {
+                    return Ok(target.size);
                 }
-                Ok(target.size)
+
+                let output = self
+                    .command_runner
+                    .run("sh", &["-c", cmd], COMMAND_CLEANUP_TIMEOUT)
+                    .map_err(|error| {
+                        cleanup_error_from_command_error(target, cmd.clone(), error)
+                    })?;
+                cleanup_result_from_output(target, output).map(|()| target.size)
             }
             CleanupMethod::CommandWithArgs(cmd, args) => {
-                if !dry_run {
-                    let output =
-                        Command::new(cmd)
-                            .args(args)
-                            .output()
-                            .map_err(|e| CleanupError {
-                                target: target.name.clone(),
-                                message: e.to_string(),
-                            })?;
-
-                    if !output.status.success() {
-                        return Err(CleanupError {
-                            target: target.name.clone(),
-                            message: String::from_utf8_lossy(&output.stderr).to_string(),
-                        });
-                    }
+                if dry_run {
+                    return Ok(target.size);
                 }
-                Ok(target.size)
+
+                let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+                let display_command = format_command(cmd, &arg_refs);
+                let output = self
+                    .command_runner
+                    .run(cmd, &arg_refs, COMMAND_CLEANUP_TIMEOUT)
+                    .map_err(|error| {
+                        cleanup_error_from_command_error(target, display_command, error)
+                    })?;
+                cleanup_result_from_output(target, output).map(|()| target.size)
             }
         }
     }
@@ -528,6 +558,38 @@ pub struct DeviceSupportInfo {
     pub full_name: String,
 }
 
+fn cleanup_result_from_output(
+    target: &CleanupTarget,
+    output: DeveloperCommandOutput,
+) -> Result<(), CleanupError> {
+    if output.status_success {
+        Ok(())
+    } else {
+        Err(CleanupError {
+            target: target.name.clone(),
+            message: String::from_utf8_lossy(&output.stderr).to_string(),
+        })
+    }
+}
+
+fn cleanup_error_from_command_error(
+    target: &CleanupTarget,
+    command: String,
+    error: DeveloperCommandError,
+) -> CleanupError {
+    let message = match error {
+        DeveloperCommandError::Io(error) => error.to_string(),
+        DeveloperCommandError::TimedOut { timeout, .. } => {
+            format!("`{}` timed out after {:?}", command, timeout)
+        }
+    };
+
+    CleanupError {
+        target: target.name.clone(),
+        message,
+    }
+}
+
 // JSON parsing structures for xcrun devicectl output
 #[derive(Debug, Deserialize)]
 struct DeviceCtlOutput {
@@ -555,7 +617,96 @@ struct DeviceCtlDeviceProperties {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::VecDeque;
+    use std::io;
+    use std::sync::Mutex;
     use tempfile::tempdir;
+
+    type MockCommandResult = Result<DeveloperCommandOutput, DeveloperCommandError>;
+
+    #[derive(Default)]
+    struct MockCommandRunner {
+        responses: Mutex<VecDeque<MockCommandResult>>,
+        calls: Mutex<Vec<(String, Vec<String>, Duration)>>,
+    }
+
+    impl MockCommandRunner {
+        fn new(responses: Vec<MockCommandResult>) -> Arc<Self> {
+            Arc::new(Self {
+                responses: Mutex::new(responses.into()),
+                calls: Mutex::new(Vec::new()),
+            })
+        }
+
+        fn success(stdout: impl Into<Vec<u8>>) -> MockCommandResult {
+            Ok(DeveloperCommandOutput {
+                status_success: true,
+                stdout: stdout.into(),
+                stderr: Vec::new(),
+            })
+        }
+
+        fn failure(stderr: impl Into<Vec<u8>>) -> MockCommandResult {
+            Ok(DeveloperCommandOutput {
+                status_success: false,
+                stdout: Vec::new(),
+                stderr: stderr.into(),
+            })
+        }
+
+        fn timeout(command: &str, timeout: Duration) -> MockCommandResult {
+            Err(DeveloperCommandError::TimedOut {
+                command: command.to_string(),
+                timeout,
+            })
+        }
+
+        fn calls(&self) -> Vec<(String, Vec<String>, Duration)> {
+            self.calls
+                .lock()
+                .expect("mock calls lock should not be poisoned")
+                .clone()
+        }
+    }
+
+    impl CommandRunner for MockCommandRunner {
+        fn run(
+            &self,
+            program: &str,
+            args: &[&str],
+            timeout: Duration,
+        ) -> Result<DeveloperCommandOutput, DeveloperCommandError> {
+            self.calls
+                .lock()
+                .expect("mock calls lock should not be poisoned")
+                .push((
+                    program.to_string(),
+                    args.iter().map(|arg| arg.to_string()).collect(),
+                    timeout,
+                ));
+
+            self.responses
+                .lock()
+                .expect("mock responses lock should not be poisoned")
+                .pop_front()
+                .unwrap_or_else(|| {
+                    Err(DeveloperCommandError::Io(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "no mock response configured",
+                    )))
+                })
+        }
+    }
+
+    fn cleaner_with_runner(runner: Arc<dyn CommandRunner>) -> XcodeCleaner {
+        XcodeCleaner::with_paths_and_runner(
+            PathBuf::from("/nonexistent"),
+            PathBuf::from("/nonexistent"),
+            PathBuf::from("/nonexistent"),
+            PathBuf::from("/nonexistent"),
+            runner,
+        )
+    }
 
     #[test]
     fn test_xcode_cleaner_creation() {
@@ -565,12 +716,7 @@ mod tests {
 
     #[test]
     fn test_scan_derived_data_empty() {
-        let cleaner = XcodeCleaner {
-            derived_data_path: PathBuf::from("/nonexistent/path"),
-            archives_path: PathBuf::from("/nonexistent/path"),
-            ios_device_support_path: PathBuf::from("/nonexistent/path"),
-            watchos_device_support_path: PathBuf::from("/nonexistent/path"),
-        };
+        let cleaner = cleaner_with_runner(MockCommandRunner::new(Vec::new()));
 
         let targets = cleaner.scan_derived_data();
         assert!(targets.is_empty());
@@ -587,12 +733,13 @@ mod tests {
         fs::create_dir(&project_dir).expect("Failed to create project directory");
         fs::write(project_dir.join("test.txt"), "test content").expect("Failed to write test file");
 
-        let cleaner = XcodeCleaner {
-            derived_data_path: derived_data,
-            archives_path: PathBuf::from("/nonexistent"),
-            ios_device_support_path: PathBuf::from("/nonexistent"),
-            watchos_device_support_path: PathBuf::from("/nonexistent"),
-        };
+        let cleaner = XcodeCleaner::with_paths_and_runner(
+            derived_data,
+            PathBuf::from("/nonexistent"),
+            PathBuf::from("/nonexistent"),
+            PathBuf::from("/nonexistent"),
+            MockCommandRunner::new(Vec::new()),
+        );
 
         let targets = cleaner.scan_derived_data();
         assert!(!targets.is_empty());
@@ -615,18 +762,103 @@ mod tests {
 
     #[test]
     fn test_get_connected_ios_versions_returns_empty_when_no_devices() {
-        // This test verifies the function handles missing devicectl gracefully
-        let cleaner = XcodeCleaner {
-            derived_data_path: PathBuf::from("/nonexistent"),
-            archives_path: PathBuf::from("/nonexistent"),
-            ios_device_support_path: PathBuf::from("/nonexistent"),
-            watchos_device_support_path: PathBuf::from("/nonexistent"),
-        };
+        // Returns empty when devicectl returns a non-success status (e.g. missing tool).
+        let runner = MockCommandRunner::new(vec![MockCommandRunner::failure(
+            "xcrun: error: unable to find utility \"devicectl\"",
+        )]);
+        let cleaner = cleaner_with_runner(runner.clone());
 
-        // Should return empty set without panicking even if devicectl fails
         let versions = cleaner.get_connected_ios_versions();
-        // Just verify it doesn't panic - actual result depends on system state
-        assert!(versions.len() <= 100); // Reasonable upper bound
+        assert!(versions.is_empty());
+
+        let calls = runner.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "xcrun");
+        assert_eq!(
+            calls[0].1,
+            vec![
+                "devicectl",
+                "list",
+                "devices",
+                "--json-output",
+                "/dev/stdout",
+            ]
+        );
+        assert_eq!(calls[0].2, XCODE_SCAN_COMMAND_TIMEOUT);
+    }
+
+    #[test]
+    fn test_get_connected_ios_versions_parses_runner_output() {
+        let json = r#"{
+            "result": {
+                "devices": [
+                    {
+                        "deviceProperties": {
+                            "osVersionNumber": "18.4.1",
+                            "platform": "iOS"
+                        }
+                    },
+                    {
+                        "deviceProperties": {
+                            "osVersionNumber": "11.6",
+                            "platform": "watchOS"
+                        }
+                    }
+                ]
+            }
+        }"#;
+        let runner = MockCommandRunner::new(vec![MockCommandRunner::success(json)]);
+        let cleaner = cleaner_with_runner(runner);
+
+        let versions = cleaner.get_connected_ios_versions();
+        assert!(versions.contains("18"));
+        assert!(!versions.contains("11"));
+    }
+
+    #[test]
+    fn test_get_connected_versions_timeout_returns_empty_set() {
+        let runner = MockCommandRunner::new(vec![MockCommandRunner::timeout(
+            "xcrun devicectl list devices",
+            XCODE_SCAN_COMMAND_TIMEOUT,
+        )]);
+        let cleaner = cleaner_with_runner(runner.clone());
+
+        let versions = cleaner.get_connected_ios_versions();
+        assert!(versions.is_empty());
+        assert_eq!(runner.calls().len(), 1);
+    }
+
+    #[test]
+    fn test_is_build_running_uses_probe_timeout() {
+        let runner = MockCommandRunner::new(vec![MockCommandRunner::success("")]);
+        let cleaner = cleaner_with_runner(runner.clone());
+
+        assert!(cleaner.is_build_running());
+
+        let calls = runner.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "pgrep");
+        assert_eq!(calls[0].1, vec!["-x", "xcodebuild"]);
+        assert_eq!(calls[0].2, COMMAND_PROBE_TIMEOUT);
+    }
+
+    #[test]
+    fn test_is_build_running_failure_returns_false() {
+        let runner = MockCommandRunner::new(vec![MockCommandRunner::failure("")]);
+        let cleaner = cleaner_with_runner(runner);
+
+        assert!(!cleaner.is_build_running());
+    }
+
+    #[test]
+    fn test_is_build_running_timeout_returns_false() {
+        let runner = MockCommandRunner::new(vec![MockCommandRunner::timeout(
+            "pgrep -x xcodebuild",
+            COMMAND_PROBE_TIMEOUT,
+        )]);
+        let cleaner = cleaner_with_runner(runner);
+
+        assert!(!cleaner.is_build_running());
     }
 
     #[test]
@@ -645,12 +877,13 @@ mod tests {
                 .expect("Failed to write fake symbols");
         }
 
-        let cleaner = XcodeCleaner {
-            derived_data_path: PathBuf::from("/nonexistent"),
-            archives_path: PathBuf::from("/nonexistent"),
-            ios_device_support_path: ios_support,
-            watchos_device_support_path: PathBuf::from("/nonexistent"),
-        };
+        let cleaner = XcodeCleaner::with_paths_and_runner(
+            PathBuf::from("/nonexistent"),
+            PathBuf::from("/nonexistent"),
+            ios_support,
+            PathBuf::from("/nonexistent"),
+            MockCommandRunner::new(Vec::new()),
+        );
 
         // With keep_latest=2, only the oldest version (16.0) should be targeted
         let targets = cleaner.get_device_support_cleanup_targets(2);
@@ -678,19 +911,24 @@ mod tests {
                 .expect("Failed to write fake symbols");
         }
 
-        let cleaner = XcodeCleaner {
-            derived_data_path: PathBuf::from("/nonexistent"),
-            archives_path: PathBuf::from("/nonexistent"),
-            ios_device_support_path: ios_support,
-            watchos_device_support_path: PathBuf::from("/nonexistent"),
-        };
+        // Both methods invoke devicectl through the runner; mock two responses
+        // (one for each smart pass: iOS + watchOS).
+        let runner = MockCommandRunner::new(vec![
+            MockCommandRunner::failure(""),
+            MockCommandRunner::failure(""),
+        ]);
+        let cleaner = XcodeCleaner::with_paths_and_runner(
+            PathBuf::from("/nonexistent"),
+            PathBuf::from("/nonexistent"),
+            ios_support,
+            PathBuf::from("/nonexistent"),
+            runner,
+        );
 
-        // Both methods should work without panicking
         let regular_targets = cleaner.get_device_support_cleanup_targets(1);
         let smart_targets = cleaner.get_device_support_cleanup_targets_smart(1);
 
         // Smart targets should be <= regular targets
-        // (smart may preserve more due to connected devices)
         assert!(smart_targets.len() <= regular_targets.len() || regular_targets.is_empty());
     }
 
@@ -739,5 +977,118 @@ mod tests {
             let major = version.split('.').next().unwrap_or(version);
             assert_eq!(major, *expected);
         }
+    }
+
+    #[test]
+    fn test_clean_dry_run_does_not_execute_command() {
+        let runner = MockCommandRunner::new(Vec::new());
+        let cleaner = cleaner_with_runner(runner.clone());
+        let target = CleanupTarget::new_command(
+            "Custom Xcode Cleanup",
+            "echo cleanup",
+            SafetyLevel::Safe,
+        )
+        .with_size(1024);
+
+        let result = cleaner.clean(&[target], true);
+
+        assert!(result.dry_run);
+        assert_eq!(result.freed_bytes, 1024);
+        assert_eq!(result.items_cleaned, 1);
+        assert!(result.errors.is_empty());
+        assert!(runner.calls().is_empty());
+    }
+
+    #[test]
+    fn test_clean_dry_run_does_not_execute_command_with_args() {
+        let runner = MockCommandRunner::new(Vec::new());
+        let cleaner = cleaner_with_runner(runner.clone());
+        let target = CleanupTarget {
+            path: None,
+            name: "Custom Xcode Cleanup".to_string(),
+            size: 4096,
+            safety_level: SafetyLevel::Safe,
+            cleanup_method: CleanupMethod::CommandWithArgs(
+                "xcrun".to_string(),
+                vec!["simctl".to_string(), "delete".to_string(), "abc".to_string()],
+            ),
+            description: None,
+        };
+
+        let result = cleaner.clean(&[target], true);
+
+        assert!(result.dry_run);
+        assert_eq!(result.freed_bytes, 4096);
+        assert_eq!(result.items_cleaned, 1);
+        assert!(result.errors.is_empty());
+        assert!(runner.calls().is_empty());
+    }
+
+    #[test]
+    fn test_clean_command_timeout_records_structured_error() {
+        let runner = MockCommandRunner::new(vec![MockCommandRunner::timeout(
+            "rm -rf /Users/test/Library/Developer/Xcode/DerivedData",
+            COMMAND_CLEANUP_TIMEOUT,
+        )]);
+        let cleaner = cleaner_with_runner(runner.clone());
+        let target = CleanupTarget::new_command(
+            "DerivedData purge",
+            "rm -rf /Users/test/Library/Developer/Xcode/DerivedData",
+            SafetyLevel::Safe,
+        )
+        .with_size(2048);
+
+        let result = cleaner.clean(&[target], false);
+
+        assert!(!result.dry_run);
+        assert_eq!(result.freed_bytes, 0);
+        assert_eq!(result.items_cleaned, 0);
+        assert_eq!(result.errors.len(), 1);
+        assert_eq!(result.errors[0].target, "DerivedData purge");
+        assert!(result.errors[0].message.contains("timed out"));
+
+        let calls = runner.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "sh");
+        assert_eq!(
+            calls[0].1,
+            vec![
+                "-c",
+                "rm -rf /Users/test/Library/Developer/Xcode/DerivedData",
+            ]
+        );
+        assert_eq!(calls[0].2, COMMAND_CLEANUP_TIMEOUT);
+    }
+
+    #[test]
+    fn test_clean_command_with_args_timeout_records_structured_error() {
+        let runner = MockCommandRunner::new(vec![MockCommandRunner::timeout(
+            "xcrun simctl delete abc",
+            COMMAND_CLEANUP_TIMEOUT,
+        )]);
+        let cleaner = cleaner_with_runner(runner.clone());
+        let target = CleanupTarget {
+            path: None,
+            name: "xcrun delete".to_string(),
+            size: 1024,
+            safety_level: SafetyLevel::Safe,
+            cleanup_method: CleanupMethod::CommandWithArgs(
+                "xcrun".to_string(),
+                vec!["simctl".to_string(), "delete".to_string(), "abc".to_string()],
+            ),
+            description: None,
+        };
+
+        let result = cleaner.clean(&[target], false);
+
+        assert!(!result.dry_run);
+        assert_eq!(result.errors.len(), 1);
+        assert!(result.errors[0].message.contains("timed out"));
+
+        let calls = runner.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "xcrun");
+        assert_eq!(calls[0].1, vec!["simctl", "delete", "abc"]);
+        assert_eq!(calls[0].2, COMMAND_CLEANUP_TIMEOUT);
     }
 }

--- a/rust-core/src/developer/xcode.rs
+++ b/rust-core/src/developer/xcode.rs
@@ -983,12 +983,9 @@ mod tests {
     fn test_clean_dry_run_does_not_execute_command() {
         let runner = MockCommandRunner::new(Vec::new());
         let cleaner = cleaner_with_runner(runner.clone());
-        let target = CleanupTarget::new_command(
-            "Custom Xcode Cleanup",
-            "echo cleanup",
-            SafetyLevel::Safe,
-        )
-        .with_size(1024);
+        let target =
+            CleanupTarget::new_command("Custom Xcode Cleanup", "echo cleanup", SafetyLevel::Safe)
+                .with_size(1024);
 
         let result = cleaner.clean(&[target], true);
 
@@ -1010,7 +1007,11 @@ mod tests {
             safety_level: SafetyLevel::Safe,
             cleanup_method: CleanupMethod::CommandWithArgs(
                 "xcrun".to_string(),
-                vec!["simctl".to_string(), "delete".to_string(), "abc".to_string()],
+                vec![
+                    "simctl".to_string(),
+                    "delete".to_string(),
+                    "abc".to_string(),
+                ],
             ),
             description: None,
         };
@@ -1074,7 +1075,11 @@ mod tests {
             safety_level: SafetyLevel::Safe,
             cleanup_method: CleanupMethod::CommandWithArgs(
                 "xcrun".to_string(),
-                vec!["simctl".to_string(), "delete".to_string(), "abc".to_string()],
+                vec![
+                    "simctl".to_string(),
+                    "delete".to_string(),
+                    "abc".to_string(),
+                ],
             ),
             description: None,
         };


### PR DESCRIPTION
Closes #267

## Summary

Migrates the Xcode and iOS Simulator cleaners (`rust-core/src/developer/xcode.rs`, `simulator.rs`) off direct `std::process::Command` calls and onto the shared `CommandRunner` trait, so every external command they spawn (`xcrun`, `pgrep`, shell-based cleanup) is now timeout-bounded and mock-friendly. This is the F19.13 follow-up to F19.11 (#258) and F19.12 (#265), completing the F19 series for the developer-tools subsystem.

### Xcode (`xcode.rs`)
- `XcodeCleaner` now holds an `Arc<dyn CommandRunner>` (defaults to `SystemCommandRunner`).
- `is_build_running()` runs `pgrep -x xcodebuild` via the runner with `COMMAND_PROBE_TIMEOUT` (2s).
- `get_connected_versions()` runs `xcrun devicectl list devices ...` via the runner with a new `XCODE_SCAN_COMMAND_TIMEOUT` (10s) and degrades to an empty version set on timeout.
- `clean_target()` routes both `CleanupMethod::Command` (shell) and `CleanupMethod::CommandWithArgs` through the runner with `COMMAND_CLEANUP_TIMEOUT` (600s); dry-run mode short-circuits before any spawn.
- Timeouts are surfaced as structured `CleanupError` entries with `\`<command>\` timed out after <duration>` messages.

### Simulator (`simulator.rs`)
- `SimulatorCleaner` now holds an `Arc<dyn CommandRunner>` (defaults to `SystemCommandRunner`).
- `list_devices()` and `list_runtimes()` run `xcrun simctl list ... -j` via the runner with a new `SIMULATOR_SCAN_COMMAND_TIMEOUT` (15s). `list_devices` surfaces timeouts as `SimulatorError::CommandTimedOut`; `list_runtimes` (best-effort, missing on older Xcode) silently degrades to an empty list on timeout.
- `delete_unavailable()` and `erase_all()` route `xcrun simctl delete/erase` through the runner with `COMMAND_CLEANUP_TIMEOUT` and short-circuit on `dry_run`.
- The `clean()` loop routes `Command` and `CommandWithArgs` through the runner and short-circuits on `dry_run`.
- `SimulatorError` gains a `CommandTimedOut` variant and a `from_developer_command_error` converter.

### Shared invariants
- Reuses `COMMAND_PROBE_TIMEOUT` / `COMMAND_CLEANUP_TIMEOUT` from `developer::mod`. Per-module SCAN timeouts (`XCODE_SCAN_COMMAND_TIMEOUT`, `SIMULATOR_SCAN_COMMAND_TIMEOUT`) mirror the `DOCKER_SCAN_COMMAND_TIMEOUT` pattern from `docker.rs`.
- Dry-run paths never spawn a subprocess and never reach the runner.
- Public API of `XcodeCleaner` / `SimulatorCleaner` is unchanged for callers that use `::new()` — only test-only constructors (`with_command_runner`, `with_paths_and_runner`) were added behind `#[cfg(test)]`.

## Acceptance criteria coverage (from #267)

| AC | Status | Where |
|----|--------|-------|
| Xcode probe/scan commands timeout-bounded | Met | `is_build_running`, `get_connected_versions` |
| Simulator probe/scan commands timeout-bounded | Met | `list_devices`, `list_runtimes` |
| Xcode and simulator command-based cleanup bounded | Met | `clean_target` (xcode), `execute_cleanup_command` / `execute_cleanup_with_args` (simulator), `delete_unavailable`, `erase_all` |
| Dry-run never executes external cleanup commands | Met | Dry-run short-circuit in `clean_target`, `clean`, `delete_unavailable`, `erase_all` |
| Timeouts reported as structured errors / unavailable probe results | Met | `CleanupError::message` on cleanup; empty result on probes |
| Mock-backed tests cover timeout and dry-run behavior without live Xcode tooling | Met | New `MockCommandRunner` test suites in both modules |

## Test Plan

`cargo` is not installed on the originating Windows host, so local verification was skipped and CI is the source of truth. New tests added in this PR:

- **xcode.rs**: `test_is_build_running_uses_probe_timeout`, `test_is_build_running_failure_returns_false`, `test_is_build_running_timeout_returns_false`, `test_get_connected_ios_versions_returns_empty_when_no_devices` (updated to use mock runner), `test_get_connected_ios_versions_parses_runner_output`, `test_get_connected_versions_timeout_returns_empty_set`, `test_clean_dry_run_does_not_execute_command`, `test_clean_dry_run_does_not_execute_command_with_args`, `test_clean_command_timeout_records_structured_error`, `test_clean_command_with_args_timeout_records_structured_error`.
- **simulator.rs**: `test_list_devices_uses_scan_timeout`, `test_list_devices_timeout_surfaces_structured_error`, `test_list_runtimes_uses_scan_timeout`, `test_list_runtimes_timeout_returns_empty_vec`, `test_get_unavailable_simulators_parses_runner_output`, `test_delete_unavailable_dry_run_does_not_execute_command`, `test_delete_unavailable_runs_command_when_not_dry_run`, `test_delete_unavailable_timeout_surfaces_structured_error`, `test_erase_all_dry_run_does_not_execute_command`, `test_erase_all_runs_command_when_not_dry_run`, `test_erase_all_timeout_surfaces_structured_error`, `test_clean_dry_run_does_not_execute_command`, `test_clean_command_timeout_records_structured_error`, `test_clean_command_with_args_timeout_records_structured_error`, `test_scan_returns_empty_when_simctl_times_out`.

Reviewers can run locally with:

```
cd rust-core
cargo test developer --locked
```

All previously existing tests that depended on direct field construction were updated to use the new `with_paths_and_runner` test helper.

Refs: #253, #258, #265
