### PR TITLE
feat(cli): enforce confirmation and dry-run semantics for destructive cleanup

### DIFF
--- a/Sources/osxcleaner/Commands/CleanCommand.swift
+++ b/Sources/osxcleaner/Commands/CleanCommand.swift
@@ -409,9 +409,31 @@ struct CleanCommand: AsyncParsableCommand {
     ) throws {
         guard plan.requiresConfirmation, !force else { return }
 
+        let risky = plan.targets.filter { target in
+            target.safetyLevel.requiresConfirmation &&
+                plan.cleanupLevel.canDelete(target.safetyLevel)
+        }
+
+        let header: String
+        if risky.isEmpty {
+            // System-level cleanup always requires confirmation even without
+            // explicit warning targets (e.g., level=system over only safe paths).
+            header = "This cleanup runs at the system level and requires confirmation."
+        } else {
+            let bulletList = risky
+                .map { target in
+                    "  - [\(shortSafetyName(target.safetyLevel))] \(target.label): \(target.path)"
+                }
+                .joined(separator: "\n")
+            header = """
+                This cleanup will delete the following risky targets:
+                \(bulletList)
+                """
+        }
+
         output.displayPrompt(
             """
-            This cleanup includes warning or system-level targets.
+            \(header)
             Estimated reclaimable space: \(previewResult.formattedFreedSpace)
             Type 'yes' to continue:
             """
@@ -443,8 +465,59 @@ struct CleanCommand: AsyncParsableCommand {
         output.display(message: "Estimated reclaimable space: \(result.formattedFreedSpace)", level: .normal)
         output.display(message: "Items matched: \(matchedItems)", level: .normal)
 
+        displayPlanTargets(plan: plan, output: output)
+        displayRiskyTargets(plan: plan, output: output)
+
+        if dryRunOnly {
+            displayDryRunPolicyHint(plan: plan, output: output)
+        }
+
         if !result.errors.isEmpty {
             output.displayWarning("Skipped \(result.errors.count) target(s) due to safety or access policy")
+        }
+    }
+
+    private func displayPlanTargets(plan: CleanupPlan, output: OutputHandler) {
+        guard !plan.targets.isEmpty else { return }
+
+        output.display(message: "Planned targets:", level: .normal)
+        for target in plan.targets {
+            let line = "  - [\(shortSafetyName(target.safetyLevel))] \(target.label): \(target.path)"
+            output.display(message: line, level: .normal)
+        }
+    }
+
+    private func displayRiskyTargets(plan: CleanupPlan, output: OutputHandler) {
+        let risky = plan.targets.filter { target in
+            target.safetyLevel.requiresConfirmation &&
+                plan.cleanupLevel.canDelete(target.safetyLevel)
+        }
+        guard !risky.isEmpty else { return }
+
+        output.display(message: "Risky targets requiring approval:", level: .normal)
+        for target in risky {
+            let line = "  ! [\(shortSafetyName(target.safetyLevel))] \(target.label): \(target.path)"
+            output.display(message: line, level: .normal)
+        }
+    }
+
+    private func displayDryRunPolicyHint(plan: CleanupPlan, output: OutputHandler) {
+        guard plan.requiresConfirmation else { return }
+        let message = "Note: a real run requires interactive 'yes' approval " +
+            "or --non-interactive --force for the targets above."
+        output.display(message: message, level: .normal)
+    }
+
+    private func shortSafetyName(_ level: SafetyLevel) -> String {
+        switch level {
+        case .safe:
+            return "safe"
+        case .caution:
+            return "caution"
+        case .warning:
+            return "warning"
+        case .danger:
+            return "danger"
         }
     }
 

--- a/Tests/osxcleanerCLITests/CleanCommandIntegrationTests.swift
+++ b/Tests/osxcleanerCLITests/CleanCommandIntegrationTests.swift
@@ -112,6 +112,126 @@ final class CleanCommandIntegrationTests: XCTestCase {
         XCTAssertNotEqual(result.exitCode, 0, result.combinedOutput)
     }
 
+    // MARK: - Preview transparency
+
+    func testDryRunPreviewListsTargetAndSafetyLevel() throws {
+        let home = try makeTemporaryDirectory(named: "home")
+        let target = try makeFile(in: home, relativePath: "Library/Caches/com.example/cache.db")
+
+        let result = try runCLI(
+            ["clean", "--level", "light", "--dry-run", "--ignore-team", target.path],
+            home: home
+        )
+
+        XCTAssertEqual(result.exitCode, 0, result.combinedOutput)
+        XCTAssertTrue(
+            result.combinedOutput.contains("Planned targets:"),
+            "preview should enumerate planned targets — got: \(result.combinedOutput)"
+        )
+        XCTAssertTrue(
+            result.combinedOutput.contains(target.path),
+            "preview should print the canonical target path — got: \(result.combinedOutput)"
+        )
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: target.path),
+            "dry-run must not delete the target"
+        )
+    }
+
+    func testDryRunOnWarningTargetEmitsPolicyHintAndRiskyList() throws {
+        let (home, target) = try makeWarningFixture()
+
+        let result = try runCLI(
+            ["clean", "--level", "deep", "--dry-run", "--ignore-team", target.path],
+            home: home
+        )
+
+        XCTAssertEqual(result.exitCode, 0, result.combinedOutput)
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: target.path),
+            "dry-run must not delete warning-level targets"
+        )
+        XCTAssertTrue(
+            result.combinedOutput.contains("Risky targets requiring approval:"),
+            "dry-run should call out risky targets — got: \(result.combinedOutput)"
+        )
+        XCTAssertTrue(
+            result.combinedOutput.contains("--non-interactive --force"),
+            "dry-run should hint at the non-interactive policy — got: \(result.combinedOutput)"
+        )
+    }
+
+    func testInteractivePromptIncludesRiskyTargetPath() throws {
+        let (home, target) = try makeWarningFixture()
+
+        let result = try runCLI(
+            ["clean", "--level", "deep", "--ignore-team", target.path],
+            home: home,
+            stdin: "no\n"
+        )
+
+        XCTAssertNotEqual(result.exitCode, 0, result.combinedOutput)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: target.path))
+        XCTAssertTrue(
+            result.combinedOutput.contains("will delete the following risky targets"),
+            "prompt should describe the risky targets — got: \(result.combinedOutput)"
+        )
+        XCTAssertTrue(
+            result.combinedOutput.contains(target.path),
+            "prompt should reveal the exact path the user is approving — got: \(result.combinedOutput)"
+        )
+    }
+
+    func testForceSuppressesInteractivePrompt() throws {
+        let (home, target) = try makeWarningFixture()
+
+        // Even when stdin says 'no', --force skips the prompt entirely and
+        // cleanup proceeds. This pins the documented contract: --force is the
+        // explicit opt-in that bypasses both the prompt (interactive) and the
+        // fail-closed gate (non-interactive).
+        let result = try runCLI(
+            ["clean", "--level", "deep", "--force", "--ignore-team", target.path],
+            home: home,
+            stdin: "no\n"
+        )
+
+        XCTAssertEqual(result.exitCode, 0, result.combinedOutput)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: target.path))
+        XCTAssertFalse(
+            result.combinedOutput.contains("Type 'yes' to continue"),
+            "--force must skip the prompt — got: \(result.combinedOutput)"
+        )
+    }
+
+    func testDryRunJSONOutputReportsDryRunTrueAndZeroFreedBytes() throws {
+        let home = try makeTemporaryDirectory(named: "home")
+        let target = try makeFile(in: home, relativePath: "Library/Caches/com.example/cache.db")
+
+        let result = try runCLI(
+            [
+                "clean",
+                "--level",
+                "light",
+                "--dry-run",
+                "--format",
+                "json",
+                "--ignore-team",
+                target.path
+            ],
+            home: home
+        )
+
+        XCTAssertEqual(result.exitCode, 0, result.combinedOutput)
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: target.path),
+            "JSON dry-run must not delete the target"
+        )
+        XCTAssertTrue(
+            result.stdout.contains("\"dry_run\":true"),
+            "JSON output should report dry_run=true — got: \(result.stdout)"
+        )
+    }
+
     private func makeWarningFixture() throws -> (home: URL, target: URL) {
         let home = try makeTemporaryDirectory(named: "home")
         let target = try makeFile(

--- a/docs/SAFETY.md
+++ b/docs/SAFETY.md
@@ -9,6 +9,7 @@
 - [Safety Philosophy](#safety-philosophy)
 - [4-Level Safety Classification](#4-level-safety-classification)
 - [Cleanup Levels Explained](#cleanup-levels-explained)
+- [Confirmation and Dry-Run Semantics](#confirmation-and-dry-run-semantics)
 - [Protected Paths](#protected-paths)
 - [What to Expect](#what-to-expect)
 - [Recovery Options](#recovery-options)
@@ -22,8 +23,8 @@ OSX Cleaner is built with a **safety-first** approach. The core principles are:
 
 1. **Never delete what you can't recover** - System files and user documents are always protected
 2. **Classify before delete** - Every path is classified before any action is taken
-3. **Confirm risky operations** - Warning-level items require explicit approval
-4. **Preview before cleanup** - Use `--dry-run` to inspect planned changes before deletion
+3. **Confirm risky operations** - Warning- and system-level items require explicit approval. In `--non-interactive` mode the command fails closed and exits non-zero unless `--force` is also passed.
+4. **Preview before cleanup** - Use `--dry-run` to inspect planned changes before deletion. See [Confirmation and Dry-Run Semantics](#confirmation-and-dry-run-semantics) for the full decision matrix.
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
@@ -184,6 +185,64 @@ sudo osxcleaner clean --level system
 > **Note:** System-level cleanup also requires confirmation, or
 > `--non-interactive --force` in automation. Even at System level, Danger paths
 > are NEVER deleted.
+
+---
+
+## Confirmation and Dry-Run Semantics
+
+The `clean` command always classifies every target before any destructive
+action runs, then routes the plan through one of three policies depending
+on the flags you pass.
+
+### Decision Matrix
+
+| Mode                                                  | Warning/system targets present? | Behavior                                                                                                          |
+|-------------------------------------------------------|---------------------------------|-------------------------------------------------------------------------------------------------------------------|
+| `--dry-run`                                           | Any                             | Print a per-target preview, never delete, exit `0`. Output includes the policy hint for the equivalent real run.   |
+| Interactive (no `--non-interactive`), no `--force`    | No                              | Cleanup runs without prompting.                                                                                    |
+| Interactive (no `--non-interactive`), no `--force`    | Yes                             | Prompt lists the risky paths and waits for `yes` on stdin. Any other answer aborts with `operation cancelled`.     |
+| `--force` (interactive or not)                        | Any                             | Prompt is skipped entirely; cleanup proceeds.                                                                      |
+| `--non-interactive` only                              | No                              | Cleanup runs without prompting.                                                                                    |
+| `--non-interactive` only                              | Yes                             | **Fail-closed.** The command exits non-zero with `--non-interactive requires --force ...` and nothing is deleted.  |
+| `--non-interactive --force`                           | Any                             | Cleanup runs without prompting and without further safety questions.                                               |
+
+Danger-level paths are blocked under every combination above and cannot be
+unlocked by `--force`.
+
+### Dry-Run Output Contract
+
+`--dry-run` always:
+
+1. Enumerates the targets that would be considered, with safety level,
+   label, and canonical path.
+2. Reports the highest safety level encountered and the estimated
+   reclaimable space.
+3. Lists the risky targets in a dedicated section when `cleanupLevel`
+   would otherwise delete them.
+4. Prints the hint: a real run requires interactive `yes` approval or
+   `--non-interactive --force` for those targets.
+5. Returns exit code `0` and performs no deletion, including for JSON
+   output (`--format json` reports `"dry_run": true` and zero freed
+   bytes).
+
+### Approval Flag Contract (`--force`)
+
+`--force` is the single explicit opt-in that bypasses both the interactive
+prompt and the non-interactive fail-closed gate. It does **not** unlock
+danger-level paths; those are still blocked.
+
+- Interactive: `--force` suppresses the `Type 'yes' to continue:` prompt
+  for the current invocation.
+- Non-interactive: `--non-interactive` without `--force` exits non-zero
+  when any warning- or system-level target is in the plan. `--force`
+  acknowledges the risk and lets cleanup proceed.
+
+### Rejection Behavior
+
+If the user answers anything other than `yes` (case-insensitive) at the
+interactive prompt, the command throws `operationCancelled` and exits
+non-zero. No deletion has happened at that point. Re-running the
+command will replay the same classification and prompt.
 
 ---
 
@@ -429,4 +488,4 @@ All operations are logged to `~/Library/Logs/osxcleaner/`:
 
 ---
 
-*Last updated: 2025-12-26*
+*Last updated: 2026-05-27*


### PR DESCRIPTION
Closes #255

## Summary

Hardens the cleanup confirmation and dry-run experience on top of the F19 baseline (PR #266) so the implemented semantics are observable to the user and codified in tests and documentation. This PR does not change the underlying safety classification, the non-interactive fail-closed gate, or the danger-level block; it makes the existing policy transparent and pins it under test.

## Acceptance Criteria Coverage

| # | Criterion | How this PR addresses it |
|---|-----------|--------------------------|
| 1 | Interactive cleanup asks for confirmation before deleting warning/system-level targets. | Prompt body now lists the risky targets by safety level, label, and canonical path. New test `testInteractivePromptIncludesRiskyTargetPath` pins this. |
| 2 | Non-interactive cleanup does not silently delete risky targets. | Existing `enforceExecutionPolicy` already fails closed; covered by pre-existing `testNonInteractiveWarningPathFailsWithoutForce`. SAFETY.md decision matrix now spells out every (mode, risky-targets) combination. |
| 3 | `--dry-run` produces a preview and performs no deletion. | Preview enumerates every planned target with safety level; dry-run over a risky plan emits a new policy hint. New tests `testDryRunPreviewListsTargetAndSafetyLevel`, `testDryRunOnWarningTargetEmitsPolicyHintAndRiskyList`, and `testDryRunJSONOutputReportsDryRunTrueAndZeroFreedBytes` pin the contract for both text and JSON formats. |
| 4 | Tests cover interactive approval, rejection, dry-run, and non-interactive failure/force behavior. | All four pre-existing paths remain. This PR adds 5 new tests, including `testForceSuppressesInteractivePrompt` to pin that `--force` bypasses both prompt and gate. |
| 5 | `docs/SAFETY.md` matches the implemented semantics. | New 'Confirmation and Dry-Run Semantics' section with decision matrix, dry-run output contract, `--force` flag contract, and rejection behavior. Principle #3 reworded to call out non-interactive fail-closed. |

## Files Modified

- `Sources/osxcleaner/Commands/CleanCommand.swift` (+74/-1): per-target preview, risky-target listing, dry-run policy hint, prompt body with concrete paths.
- `Tests/osxcleanerCLITests/CleanCommandIntegrationTests.swift` (+120): 5 new integration tests for preview transparency, prompt body content, --force prompt bypass, and JSON dry-run.
- `docs/SAFETY.md` (+62/-3): decision matrix, dry-run contract, --force contract, rejection behavior.

## Approval Flag Decision

Kept the existing `--force` flag (introduced in PR #266) rather than introducing a new `--accept-risk` / `--yes` alias.

Rationale:
- Already documented in the command's `discussion` block and in pre-existing tests.
- Already referenced from `docs/SAFETY.md` and from the cleanup level tables.
- Sibling commands (`config reset`, `audit clear`) use the same `--force` convention. Introducing a new flag would fragment the CLI surface.
- The semantic contract is now explicitly documented in SAFETY.md: `--force` bypasses the prompt and the non-interactive fail-closed gate, but does not unlock danger-level paths.

## Non-Interactive Failure Behavior

`--non-interactive` without `--force` exits non-zero with the message:

```
--non-interactive requires --force for warning or system-level cleanup
```

This is the existing behavior from PR #266; this PR documents and tests it but does not change it. Cleanup does not proceed and no files are deleted in this path.

## Local Verification

Swift toolchain is not available on this Windows host (`command -v swift` is empty). Per `build-verification.md` and the project's documented test workflow, local Swift build/test was skipped and CI is authoritative for compilation and test execution.

What was verified locally:
- Static review of the new methods against existing patterns in `CleanCommand.swift` and `CleanCommandIntegrationTests.swift`.
- No new dependencies, no public API changes outside the command itself.
- Pre-existing test helpers (`runCLI`, `makeWarningFixture`, `makeFile`) reused without modification.

## Out of Scope

- The underlying `SafetyLevel` / `CleanupLevel` enums are unchanged.
- The danger-level block in `enforceExecutionPolicy` is unchanged.
- The `CleanerService` cleanup loop is unchanged.
- GUI `CleanView` is unchanged (separate concern; this issue targets the CLI semantics).