### PR TITLE
ci(build): align workflows with XCFramework prerequisite and lockfile policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,13 @@ env:
   RUST_BACKTRACE: 1
   MACOSX_DEPLOYMENT_TARGET: "14.0"
 
+# Cache key policy (F19.4.2 / issue #272):
+# - rust-core/Cargo.lock and Package.resolved are tracked in git for
+#   reproducibility (see .gitignore comments). Cache keys hash these lockfiles
+#   so the cache stays warm across CI runs with the same dependency graph.
+# - Frameworks/COSXCore.xcframework is NOT tracked. Every Swift-bearing job
+#   must run `make xcframework` before any `swift build` / `swift test`.
+
 jobs:
   # Rust jobs
   rust-check:
@@ -114,8 +121,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-full-
 
-      - name: Build from clean checkout
-        run: make build
+      - name: Build XCFramework (universal arm64 + x86_64)
+        run: make xcframework
+
+      - name: Build Swift package (after XCFramework prerequisite)
+        run: make swift
 
       - name: Run all tests
         run: make test

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,6 +15,13 @@ env:
   RUST_BACKTRACE: 1
   MACOSX_DEPLOYMENT_TARGET: "14.0"
 
+# Cache key policy (F19.4.2 / issue #272):
+# - rust-core/Cargo.lock is tracked in git (see .gitignore comments) so the
+#   cache key resolves to a real file. cargo-audit/deny only need lockfile
+#   metadata, so neither job builds the XCFramework.
+# - SwiftLint operates on source files alone (no SwiftPM resolution required),
+#   so swiftlint-security also skips `make xcframework`.
+
 jobs:
   # Rust dependency vulnerability scanning
   cargo-audit:

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ DerivedData/
 .build/
 .swiftpm/
 # Package.resolved is tracked for application/CLI reproducibility.
+# See F19.4.2 (issue #272): CI cache keys hash Package.resolved, so the file
+# must be committed. Do NOT add Package.resolved to this ignore list.
 Packages/
 *.playground/timeline.xctimeline
 *.playground/playground.xcworkspace
@@ -42,6 +44,8 @@ Packages/
 # =============================================================================
 target/
 # Cargo.lock is tracked for application/CLI reproducibility.
+# See F19.4.2 (issue #272): CI cache keys hash rust-core/Cargo.lock, so the
+# file must be committed for deterministic builds. Do NOT ignore Cargo.lock.
 **/*.rs.bk
 
 # =============================================================================


### PR DESCRIPTION
@
## Summary

Address F19.4.2 (#272): align the CI pipeline with the documented clean-checkout build flow and lock in the lockfile-tracking policy.

## What changed

- **`.github/workflows/ci.yml`** - In the `Full Build` job, replaced the opaque `make build` step with explicit `make xcframework` + `make swift` steps, so the XCFramework prerequisite is visible in the run summary just like in `swift-check` and `coverage`. Added a workflow-level comment documenting the cache-key contract (lockfiles tracked, XCFramework not).
- **`.github/workflows/security.yml`** - Added the same cache-key policy comment. No structural change: `cargo-audit`/`cargo-deny` only need `rust-core/Cargo.lock` (already tracked) and `swiftlint-security` operates on source files alone, so none of the security jobs build the XCFramework.
- **`.gitignore`** - Cross-referenced F19.4.2 next to the existing `Package.resolved` and `rust-core/Cargo.lock` comments to prevent future regressions ("Do NOT ignore these files").

## Lockfile policy

**Option A (track lockfiles)** - chosen and documented.

Both `Package.resolved` and `rust-core/Cargo.lock` were already committed and `.gitignore` already excluded them from the ignore rules; this PR only documents the rationale alongside the cache-key contract. No new lockfile content is being added in this PR.

## Acceptance criteria mapping

- [x] CI workflows run `make xcframework` before Swift build/test steps - all three Swift-bearing jobs in `ci.yml` (`swift-check`, `Full Build`, `coverage`) now have an explicit `make xcframework` step.
- [x] `.gitignore` and CI cache keys are consistent with the chosen lockfile policy - documented in both files with a single source of truth comment.
- [x] CI cache hit rate is observable - cache keys hash tracked files (`hashFiles(rust-core/Cargo.lock)`, `hashFiles(Package.resolved)`), so the same SHA resolves to the same key on repeat runs.
- [x] Dependency resolution is deterministic - tracked lockfiles pin versions across local and CI.

## Sibling work

- #271 (F19.4.1) is being worked in parallel and touches `Makefile`, `scripts/build-xcframework.sh`, and `rust-core/Cargo.toml`. This PR is scoped strictly to CI workflows and `.gitignore` to avoid conflicts.

## Test plan

- YAML syntax validated locally for both workflows.
- Full CI run on this branch exercises the new explicit XCFramework step in the `Full Build` job. The `swift-check` and `coverage` jobs were already running `make xcframework`, so behaviour there is unchanged.

Closes #272
Refs #257, #253
@