### PR TITLE
docs(build): align README and TESTING.md with canonical first-build sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,34 +336,52 @@ For detailed documentation, see [Monitoring Guide](docs/monitoring/MONITORING.md
 
 ### Manual Build
 
+The canonical first-build sequence on a fresh clone matches what CI runs in the
+`Full Build` job (`.github/workflows/ci.yml`):
+
 ```bash
-# Fresh clone first build (universal XCFramework + Swift release binaries)
-make build
+# 1. Verify required toolchains (rustc, cargo, swift, lipo, xcodebuild,
+#    and both aarch64-apple-darwin / x86_64-apple-darwin Rust targets).
+make check-prereqs
 
-# Backward-compatible alias for the same full build
-make all
+# 2. Build the universal XCFramework (Frameworks/COSXCore.xcframework)
+#    that wraps the Rust core for SwiftPM's binaryTarget.
+make xcframework
 
-# Run tests (Rust + Swift; Swift step automatically builds the XCFramework first)
+# 3. Build the Swift package against the XCFramework just produced.
+make swift
+```
+
+After this sequence, direct `swift build` and `swift test` commands work
+because the local binary target (`Frameworks/COSXCore.xcframework`) is in
+place. Common follow-up targets:
+
+```bash
+# Run all tests (Rust + Swift)
 make test
 
 # Build for development (Swift debug; still requires the XCFramework)
 make debug
 
-# Rebuild only the universal XCFramework (Frameworks/COSXCore.xcframework)
-make xcframework
+# One-shot convenience alias for steps 2 + 3 above
+make build
 ```
 
 The Swift package consumes the Rust core through
 `Frameworks/COSXCore.xcframework`, a universal (`arm64` + `x86_64`) static
 library wrapped via SwiftPM's `binaryTarget`. It is **not** committed to the
-repository, so the supported clean-checkout path is `make build` (or `make`
-with no target). Direct `swift build`/`swift test` commands are supported only
-after `make xcframework` has generated the local binary target.
+repository, so direct `swift build`/`swift test` commands require a prior
+`make xcframework`.
 
-Dependency lockfiles are committed for reproducibility:
-`Package.resolved` pins SwiftPM dependencies and `rust-core/Cargo.lock` pins
-Rust dependencies. When changing dependencies, update and commit the matching
-lockfile with the manifest change.
+If `make check-prereqs` reports missing tooling, it forwards to
+`./scripts/build-xcframework.sh --check`, which prints actionable diagnostics
+(for example, the exact `rustup target add` invocation needed, or alternatives
+when `rustup` is not installed).
+
+Dependency lockfiles `Package.resolved` and `rust-core/Cargo.lock` are tracked
+for reproducibility; CI cache keys hash them so the cache stays warm across
+runs with the same dependency graph. When changing dependencies, update and
+commit the matching lockfile with the manifest change.
 
 ---
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -61,25 +61,47 @@ osx_cleaner/
 
 ## Running Tests
 
+### Prerequisites
+
+Before running any Swift test target, complete the canonical first-build
+sequence (matches `Full Build` in `.github/workflows/ci.yml`):
+
+```bash
+# 1. Verify required toolchains (rustc, cargo, swift, lipo, xcodebuild,
+#    and both aarch64-apple-darwin / x86_64-apple-darwin Rust targets).
+make check-prereqs
+
+# 2. Build the universal XCFramework that Swift tests link against.
+make xcframework
+
+# 3. Build the Swift package (also runs the prerequisite XCFramework step).
+make swift
+```
+
+Rust-only tests (`cd rust-core && cargo test`) do not require step 2, but the
+Swift test targets do. If `make check-prereqs` reports missing tooling, it
+forwards to `./scripts/build-xcframework.sh --check`, which prints actionable
+diagnostics for resolving the gap.
+
+Dependency lockfiles `Package.resolved` and `rust-core/Cargo.lock` are tracked
+for reproducibility.
+
 ### Quick Commands
 
 ```bash
-# Fresh clone first build; generates Frameworks/COSXCore.xcframework
-make build
-
-# Run all tests (Rust + Swift)
+# Run all tests (Rust + Swift; the Swift step rebuilds the XCFramework if needed)
 make test
 
 # Run only Rust tests
 cd rust-core && cargo test
 
-# Run only Swift tests; generates the XCFramework first
+# Run only Swift tests (depends on the XCFramework; rebuilt automatically)
 make test-swift
 
 # Run only CLI integration tests
 make test-cli
 
-# Run Swift coverage after the XCFramework bootstrap
+# Run Swift coverage on top of the canonical first-build sequence
 make xcframework
 swift test --enable-code-coverage
 ```
@@ -87,8 +109,6 @@ swift test --enable-code-coverage
 The Swift package has a local binary target at
 `Frameworks/COSXCore.xcframework`. It is generated, not committed, so direct
 `swift build` or `swift test` commands require a prior `make xcframework`.
-Use `./scripts/build-xcframework.sh --check` when diagnosing missing local
-build prerequisites.
 
 ### Detailed Commands
 
@@ -118,10 +138,12 @@ cargo llvm-cov --all-features
 #### Swift Tests
 
 ```bash
-# Run all tests from a clean checkout
+# Run all Swift tests from a clean checkout (rebuilds the XCFramework if needed)
 make test-swift
 
-# Or bootstrap once, then run SwiftPM directly
+# Or bootstrap once, then run SwiftPM directly. This sequence matches the
+# CI Full Build job in .github/workflows/ci.yml.
+make check-prereqs
 make xcframework
 swift build --product osxcleaner
 OSXCLEANER_CLI_PATH="$(swift build --show-bin-path)/osxcleaner" swift test
@@ -142,8 +164,10 @@ swift test --no-parallel
 ### Integration Tests
 
 ```bash
-# Build and test full integration
-make build
+# Canonical first-build sequence, then run all tests
+make check-prereqs
+make xcframework
+make swift
 make test
 
 # Test CLI directly
@@ -397,7 +421,13 @@ The `.github/workflows/ci.yml` runs:
    - Build (`swift build`)
    - Unit tests (`swift test`)
 
-3. **Coverage**
+3. **Full Build**
+   - XCFramework bootstrap (`make xcframework`)
+   - Swift package build (`make swift`)
+   - All tests (`make test`)
+   - CLI smoke check (`.build/release/osxcleaner --version`)
+
+4. **Coverage**
    - XCFramework bootstrap (`make xcframework`)
    - Swift coverage with llvm-cov
    - Rust coverage with cargo-llvm-cov


### PR DESCRIPTION
## Summary

Reconcile `README.md` and `docs/TESTING.md` so a fresh clone has a single, unambiguous first-build command sequence that matches what CI runs in the `Full Build` job of `.github/workflows/ci.yml`.

This is the third and final sub-issue of #257 (F19.4). The dependency work is already in:
- **Depends on (already merged): #271 / #275** (actionable diagnostics, `make check-prereqs`, cross-target rustflags safety-net)
- **Depends on (already merged): #272 / #274** (CI command split into `make xcframework` \xe2\x86\x92 `make swift`, lockfile policy documented)

## Canonical first-build sequence

The documentation now points new contributors at exactly one sequence, which mirrors the CI `Full Build` job step-for-step:

```bash
make check-prereqs   # validate rustc, cargo, swift, lipo, xcodebuild, and Apple Rust targets
make xcframework     # build Frameworks/COSXCore.xcframework (universal arm64 + x86_64)
make swift           # build the Swift package against the XCFramework just produced
```

After this, direct `swift build` / `swift test` work because the local binary target is in place. `make build` remains available as a one-shot alias for steps 2 + 3.

## Changes

### `README.md` (Manual Build section)
- Replace divergent guidance with the three-step canonical sequence
- Add a brief pointer to `scripts/build-xcframework.sh --check` for actionable diagnostics on failure (from #271/#275)
- Note that `Package.resolved` and `rust-core/Cargo.lock` are tracked for reproducibility and that CI cache keys hash them (from #272/#274)

### `docs/TESTING.md`
- New **Prerequisites** subsection mirroring the README's three-step sequence
- Update **Swift Tests** and **Integration Tests** snippets to use the same sequence
- Add the **Full Build** CI job to the CI Workflow list (was previously missing) so it matches `.github/workflows/ci.yml`

## Verification

- Documented sequence compared side-by-side against `.github/workflows/ci.yml` `build` job (steps `make xcframework`, `make swift`, `make test`)
- Makefile targets (`check-prereqs`, `xcframework`, `swift`, `build`, `test`) all exist and behave as described
- Documentation-only change \xe2\x80\x94 no source or workflow modifications

## Acceptance Criteria

- [x] `README.md` and `docs/TESTING.md` describe the same prerequisites and the same first-build command sequence
- [x] The documented command sequence matches the CI workflow steps (verifiable by reading both side-by-side)
- [x] A new contributor following only `README.md` can build successfully on a fresh clone

Closes #273