### PR TITLE
fix(build): link OpenDirectory framework for sysinfo 0.39

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -55,7 +55,14 @@ let package = Package(
                 .product(name: "Crypto", package: "swift-crypto"),
                 .product(name: "Yams", package: "Yams")
             ],
-            path: "Sources/OSXCleanerKit"
+            path: "Sources/OSXCleanerKit",
+            linkerSettings: [
+                // sysinfo (>= 0.39) resolves macOS users via OpenDirectory.
+                // The static library is repackaged into COSXCore.xcframework,
+                // which drops the crate's `#[link]` directive, so the framework
+                // must be linked explicitly here for every downstream consumer.
+                .linkedFramework("OpenDirectory")
+            ]
         ),
         // Tests
         .testTarget(

--- a/rust-core/Cargo.lock
+++ b/rust-core/Cargo.lock
@@ -289,6 +289,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,12 +606,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
 ]
 
 [[package]]
@@ -612,6 +649,17 @@ checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -930,15 +978,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.38.4"
+version = "0.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+checksum = "21d0d938c10fcda3e897e28aaddf4ab462375d411f4378cd63b1c945f69aba96"
 dependencies = [
  "libc",
  "memchr",
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
+ "objc2-open-directory",
  "windows",
 ]
 

--- a/rust-core/Cargo.toml
+++ b/rust-core/Cargo.toml
@@ -30,7 +30,7 @@ log = "0.4"
 env_logger = "0.11"
 
 # System information
-sysinfo = "0.38"
+sysinfo = "0.39"
 
 # Glob pattern matching
 glob = "0.3"


### PR DESCRIPTION
## Summary

Prepares `develop` for the F19 release to `main` by reconciling the sysinfo
dependency and its macOS framework requirement.

`main` carries `sysinfo = 0.39` (#252) while `develop` was on `0.38`. sysinfo
0.39 resolves macOS users via OpenDirectory (the `objc2-open-directory` crate).
Because the Rust static library is repackaged into `COSXCore.xcframework`, the
crate's `#[link]` directive does not survive to the final Swift link step, so a
straight `develop → main` merge fails to link the executables with undefined
`_kOD*` symbols (observed on PR #278).

## Changes
- `rust-core/Cargo.toml`: `sysinfo 0.38 → 0.39` (+ `Cargo.lock`, pulling
  `objc2-open-directory` and friends)
- `Package.swift`: link `OpenDirectory` from `OSXCleanerKit` so the framework
  propagates to the CLI, GUI, and test targets

## Test Plan
- `cargo build --release` passes locally with sysinfo 0.39.3.
- CI (Swift Check / Full Build / Code Coverage) validates the OpenDirectory link
  that cannot be exercised on a host without the XCFramework toolchain.

Follow-up: re-open release PR #278 (`develop → main`) once this lands.